### PR TITLE
Add theme switch in landing page #16

### DIFF
--- a/frontend/app/components/ui/hero-section.tsx
+++ b/frontend/app/components/ui/hero-section.tsx
@@ -5,52 +5,49 @@ import * as React from "react";
 
 export function HeroSection() {
 	return (
-		<div className="relative flex flex-col items-center justify-center min-h-[90vh] text-center px-4 overflow-hidden">
+		<div className="relative flex flex-col items-center justify-center min-h-[90vh] text-center px-4 overflow-hidden dark:bg-gray-900 dark:text-white">
 			{/* Gradient Background */}
-			<div className="absolute inset-0 bg-gradient-to-br from-primary/10 via-background to-background" />
+			<div className="absolute inset-0 bg-gradient-to-br from-primary/10 via-background to-background dark:from-primary/5 dark:via-gray-800 dark:to-gray-900" />
 
 			{/* Animated Grid Background */}
-			<div className="absolute inset-0 bg-[linear-gradient(to_right,#8882_1px,transparent_1px),linear-gradient(to_bottom,#8882_1px,transparent_1px)] bg-[size:14px_24px] [mask-image:radial-gradient(ellipse_60%_50%_at_50%_0%,#000_70%,transparent_100%)]" />
+			<div className="absolute inset-0 bg-[linear-gradient(to_right,#8882_1px,transparent_1px),linear-gradient(to_bottom,#8882_1px,transparent_1px)] bg-[size:14px_24px] [mask-image:radial-gradient(ellipse_60%_50%_at_50%_0%,#000_70%,transparent_100%)] dark:bg-[linear-gradient(to_right,#444_1px,transparent_1px),linear-gradient(to_bottom,#444_1px,transparent_1px)]" />
 
 			<div className="relative z-10">
-				<div className="inline-flex items-center gap-2 px-4 py-2 rounded-full bg-primary/10 text-primary mb-8">
+				<div className="inline-flex items-center gap-2 px-4 py-2 rounded-full bg-primary/10 text-primary mb-8 dark:bg-primary/20 dark:text-primary/80">
 					<span className="relative flex h-2 w-2">
-						<span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-primary opacity-75" />
-						<span className="relative inline-flex rounded-full h-2 w-2 bg-primary" />
+						<span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-primary opacity-75 dark:opacity-50" />
+						<span className="relative inline-flex rounded-full h-2 w-2 bg-primary dark:bg-primary/70" />
 					</span>
 					Live on Stellar Network
 				</div>
 
-				<h1 className="text-4xl sm:text-6xl font-bold tracking-tight mb-8 bg-clip-text from-primary to-primary/70">
+				<h1 className="text-4xl sm:text-6xl font-bold tracking-tight mb-8 bg-clip-text from-primary to-primary/70 dark:text-primary">
 					The Future of
 					<span className="block mt-2">Secure Trading</span>
 				</h1>
 
-				<p className="text-xl text-muted-foreground max-w-[600px] mb-12">
+				<p className="text-xl text-muted-foreground max-w-[600px] mb-12 dark:text-gray-400">
 					Experience trustless trading with built-in Stellar escrow protection.
 					Your gateway to secure, decentralized commerce.
 				</p>
 
 				<div className="flex flex-col sm:flex-row gap-4 justify-center items-center">
 					<Button size="lg" className="group">
-						<Wallet className="mr-2 h-4 w-4 transition-transform group-hover:scale-110" />
+						<Wallet className="mr-2 h-4 w-4 transition-transform group-hover:scale-110 dark:text-white" />
 						Connect Wallet
 					</Button>
-					<Link
-						href="/marketplace
-		  "
-					>
+					<Link href="/marketplace">
 						<Button variant="outline" size="lg" className="group">
 							Explore Marketplace
-							<ArrowRight className="ml-2 h-4 w-4 transition-transform group-hover:translate-x-1" />
+							<ArrowRight className="ml-2 h-4 w-4 transition-transform group-hover:translate-x-1 dark:text-white" />
 						</Button>
 					</Link>
 				</div>
 
 				{/* Live Stats Ticker */}
-				<div className="mt-16 flex gap-8 justify-center items-center text-sm text-muted-foreground">
+				<div className="mt-16 flex gap-8 justify-center items-center text-sm text-muted-foreground dark:text-gray-400">
 					<div className="flex items-center gap-2">
-						<span className="inline-block w-2 h-2 rounded-full bg-green-500"></span>
+						<span className="inline-block w-2 h-2 rounded-full bg-green-500 dark:bg-green-400"></span>
 						Network Status: Active
 					</div>
 					<div>24h Volume: $1.2M</div>

--- a/frontend/app/components/ui/stats-section.tsx
+++ b/frontend/app/components/ui/stats-section.tsx
@@ -4,7 +4,7 @@ export function StatsSection() {
 	return (
 		<div className="relative py-20 overflow-hidden">
 			{/* Decorative elements */}
-			<div className="absolute inset-0 bg-primary/5 -skew-y-6 transform origin-top-left" />
+			<div className="absolute inset-0 bg-primary/5 transform origin-top-left" />
 
 			<div className="relative max-w-6xl mx-auto px-4">
 				<div className="grid grid-cols-1 md:grid-cols-3 gap-8">

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -7,38 +7,39 @@ import { useEffect, useState } from "react";
 import { IoMoon, IoSunny } from "react-icons/io5";
 
 export default function Home() {
-	const [dark, setDark] = useState(() => {
-		return JSON.parse(localStorage.getItem("darkMode") || "false");
-	});
+  const [dark, setDark] = useState(() => {
+    return JSON.parse(localStorage.getItem("darkMode") || "false");
+  });
 
-	useEffect(() => {
-		document.documentElement.classList.toggle("dark", dark);
-		localStorage.setItem("darkMode", JSON.stringify(dark));
-	}, [dark]);
+  useEffect(() => {
+    document.documentElement.classList.toggle("dark", dark);
+    localStorage.setItem("darkMode", JSON.stringify(dark));
+  }, [dark]);
 
-	return (
-		<main className="flex min-h-screen flex-col">
-			<button
-				onClick={() => setDark(!dark)}
-				style={{
-					position: "absolute",
-					margin: "20px",
-					width: "25px",
-					height: "25px",
-					right: 0,
-					top: 0,
-					zIndex: 1000,
-				}}
-			>
-				{dark ? (
-					<IoSunny style={{ width: "25px", height: "25px" }} />
-				) : (
-					<IoMoon style={{ width: "25px", height: "25px" }} />
-				)}
-			</button>
-			<HeroSection />
-			<StatsSection />
-			<FeatureSection />
-		</main>
-	);
+  return (
+    <main className="flex min-h-screen flex-col">
+      <button
+        onClick={() => setDark(!dark)}
+        style={{
+          position: "absolute",
+          margin: "20px",
+          width: "25px",
+          height: "25px",
+          right: 0,
+          top: 0,
+          zIndex: 1000,
+        }}
+      >
+        {dark ? (
+          <IoSunny style={{ width: "25px", height: "25px" }} />
+        ) : (
+          <IoMoon style={{ width: "25px", height: "25px" }} />
+        )}
+      </button>
+      <HeroSection />
+      <StatsSection />
+      <FeatureSection />
+    </main>
+  );
 }
+

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -1,10 +1,41 @@
+"use client";
+
 import { FeatureSection } from "@/app/components/ui/feature-section";
 import { HeroSection } from "@/app/components/ui/hero-section";
 import { StatsSection } from "@/app/components/ui/stats-section";
+import { useEffect, useState } from "react";
+import { IoMoon, IoSunny } from "react-icons/io5";
 
 export default function Home() {
+	const [dark, setDark] = useState(() => {
+		return JSON.parse(localStorage.getItem("darkMode") || "false");
+	});
+
+	useEffect(() => {
+		document.documentElement.classList.toggle("dark", dark);
+		localStorage.setItem("darkMode", JSON.stringify(dark));
+	}, [dark]);
+
 	return (
 		<main className="flex min-h-screen flex-col">
+			<button
+				onClick={() => setDark(!dark)}
+				style={{
+					position: "absolute",
+					margin: "20px",
+					width: "25px",
+					height: "25px",
+					right: 0,
+					top: 0,
+					zIndex: 1000,
+				}}
+			>
+				{dark ? (
+					<IoSunny style={{ width: "25px", height: "25px" }} />
+				) : (
+					<IoMoon style={{ width: "25px", height: "25px" }} />
+				)}
+			</button>
 			<HeroSection />
 			<StatsSection />
 			<FeatureSection />

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -18,6 +18,7 @@
 				"next": "14.2.16",
 				"react": "^18",
 				"react-dom": "^18",
+				"react-icons": "^5.3.0",
 				"sharp": "^0.33.5",
 				"tailwind-merge": "^2.5.4",
 				"tailwindcss-animate": "^1.0.7"
@@ -5340,6 +5341,14 @@
 			},
 			"peerDependencies": {
 				"react": "^18.3.1"
+			}
+		},
+		"node_modules/react-icons": {
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.3.0.tgz",
+			"integrity": "sha512-DnUk8aFbTyQPSkCfF8dbX6kQjXA9DktMeJqfjrg6cK9vwQVMxmcA3BfP4QoiztVmEHtwlTgLFsPuH2NskKT6eg==",
+			"peerDependencies": {
+				"react": "*"
 			}
 		},
 		"node_modules/react-is": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -19,6 +19,7 @@
 		"next": "14.2.16",
 		"react": "^18",
 		"react-dom": "^18",
+		"react-icons": "^5.3.0",
 		"sharp": "^0.33.5",
 		"tailwind-merge": "^2.5.4",
 		"tailwindcss-animate": "^1.0.7"


### PR DESCRIPTION
# 📝 Pull Request Title
- Add theme switch in landing page #16

## 🛠️ Issue
- Closes #16 

## 📖 Description
- We want to introduce a theme switcher on the landing page to toggle between light and dark modes.

## ✅ Changes made
- Added a switch to enable and disable dark mode
- The app remembers previous dark or light mode saving a variable in localstorage to achieve this
- Installed react-icons for the icons

## 📜 Additional Notes
- So, this page uses Tailwind for styles, Tailwind already has some docs to implement this https://tailwindcss.com/docs/dark-mode
- Here is the guide I followed to implement this https://mujeebkhan1831.medium.com/how-to-implement-darkmode-in-react-using-tailwind-css-3c47d009209a
- This implementation should work for all the components inside the page tsx
- In case you want to add more styles, make sure to add `dark:` to the classes, look at the hero tsx, when It's in dark mode, the classes with `dark:` will be taken

## Screenshots
<img width="1352" alt="Captura de pantalla 2024-11-25 a la(s) 6 09 05 p  m" src="https://github.com/user-attachments/assets/2380ac20-109e-4b4d-8b39-8d3850cd46d7">
<img width="1352" alt="Captura de pantalla 2024-11-25 a la(s) 6 08 30 p  m" src="https://github.com/user-attachments/assets/d6df72d7-befd-4a28-970e-8a058549dcd5">
