### PR TITLE
feat: create my products page

### DIFF
--- a/apps/frontend/app/my-products/layout.tsx
+++ b/apps/frontend/app/my-products/layout.tsx
@@ -1,0 +1,16 @@
+import Footer from "@/components/shared/footer";
+import Header from "@/components/shared/header/header";
+
+export default function MyProductsLayout({
+	children,
+}: {
+	children: React.ReactNode;
+}) {
+	return (
+		<div className="flex flex-col min-h-screen">
+			<Header />
+			<main className="flex-grow container pb-10 mx-auto">{children}</main>
+			<Footer />
+		</div>
+	);
+}

--- a/apps/frontend/app/my-products/page.tsx
+++ b/apps/frontend/app/my-products/page.tsx
@@ -11,9 +11,23 @@ import {
 	TableRow,
 } from "@/components/ui/table";
 import { products as initialProducts } from "@/lib/mocks/products";
-import { ArrowDownUp, Eye, Plus, SquarePen, Trash2 } from "lucide-react";
+import {
+	ArrowDown,
+	ArrowDownUp,
+	ArrowUp,
+	Eye,
+	Plus,
+	SquarePen,
+	Trash2,
+} from "lucide-react";
 import Image from "next/image";
 import { useState } from "react";
+
+const columnMappings: Record<string, keyof (typeof initialProducts)[0]> = {
+	Product: "name",
+	Category: "category",
+	Price: "price",
+};
 
 export default function MyProductsPage() {
 	const [sortColumn, setSortColumn] = useState<
@@ -21,12 +35,6 @@ export default function MyProductsPage() {
 	>(null);
 	const [sortOrder, setSortOrder] = useState<"asc" | "desc">("asc");
 	const [searchQuery, setSearchQuery] = useState("");
-
-	const columnMappings: Record<string, keyof (typeof initialProducts)[0]> = {
-		Product: "name",
-		Category: "category",
-		Price: "price",
-	};
 
 	const sortedProducts = [...initialProducts]
 		.filter(
@@ -91,11 +99,20 @@ export default function MyProductsPage() {
 							{Object.keys(columnMappings).map((col) => (
 								<TableHead key={col} className="cursor-pointer">
 									<button
+										type="button"
 										onClick={() => handleSort(col)}
 										className="flex items-center gap-3"
 									>
 										{col}
-										<ArrowDownUp className="w-5 h-5" />
+										{sortColumn === columnMappings[col] ? (
+											sortOrder === "asc" ? (
+												<ArrowUp size={16} />
+											) : (
+												<ArrowDown size={16} />
+											)
+										) : (
+											<ArrowDownUp size={16} />
+										)}
 									</button>
 								</TableHead>
 							))}

--- a/apps/frontend/app/my-products/page.tsx
+++ b/apps/frontend/app/my-products/page.tsx
@@ -1,0 +1,148 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+	Table,
+	TableBody,
+	TableCell,
+	TableHead,
+	TableHeader,
+	TableRow,
+} from "@/components/ui/table";
+import { products as initialProducts } from "@/lib/mocks/products";
+import { ArrowDownUp, Eye, Plus, SquarePen, Trash2 } from "lucide-react";
+import Image from "next/image";
+import { useState } from "react";
+
+export default function MyProductsPage() {
+	const [sortColumn, setSortColumn] = useState<
+		keyof (typeof initialProducts)[0] | null
+	>(null);
+	const [sortOrder, setSortOrder] = useState<"asc" | "desc">("asc");
+	const [searchQuery, setSearchQuery] = useState("");
+
+	const columnMappings: Record<string, keyof (typeof initialProducts)[0]> = {
+		Product: "name",
+		Category: "category",
+		Price: "price",
+	};
+
+	const sortedProducts = [...initialProducts]
+		.filter(
+			(product) =>
+				product.name.toLowerCase().includes(searchQuery.toLowerCase()) ||
+				product.category.toLowerCase().includes(searchQuery.toLowerCase()),
+		)
+		.sort((a, b) => {
+			if (!sortColumn) return 0;
+			const valueA = a[sortColumn];
+			const valueB = b[sortColumn];
+
+			if (typeof valueA === "string" && typeof valueB === "string") {
+				return sortOrder === "asc"
+					? valueA.localeCompare(valueB)
+					: valueB.localeCompare(valueA);
+			}
+
+			if (typeof valueA === "number" && typeof valueB === "number") {
+				return sortOrder === "asc" ? valueA - valueB : valueB - valueA;
+			}
+
+			return 0;
+		});
+
+	const handleSort = (columnKey: string) => {
+		const column = columnMappings[columnKey];
+		if (sortColumn === column) {
+			setSortOrder(sortOrder === "asc" ? "desc" : "asc");
+		} else {
+			setSortColumn(column);
+			setSortOrder("asc");
+		}
+	};
+
+	return (
+		<section className="py-4 space-y-10">
+			<div className="flex justify-between items-center">
+				<div>
+					<h1 className="capitalize text-3xl font-bold">
+						my products ({sortedProducts.length})
+					</h1>
+					<p className="text-muted-foreground">
+						These are the products you want to sell.
+					</p>
+				</div>
+				<Button>
+					<Plus /> Sell a Product
+				</Button>
+			</div>
+
+			<div className="space-y-4">
+				<Input
+					placeholder="Search products..."
+					className="w-96"
+					value={searchQuery}
+					onChange={(e) => setSearchQuery(e.target.value)}
+				/>
+				<Table className="border">
+					<TableHeader>
+						<TableRow>
+							{Object.keys(columnMappings).map((col) => (
+								<TableHead key={col} className="cursor-pointer">
+									<button
+										onClick={() => handleSort(col)}
+										className="flex items-center gap-3"
+									>
+										{col}
+										<ArrowDownUp className="w-5 h-5" />
+									</button>
+								</TableHead>
+							))}
+							<TableHead>Actions</TableHead>
+						</TableRow>
+					</TableHeader>
+					<TableBody>
+						{sortedProducts.length > 0 ? (
+							sortedProducts.map((product) => (
+								<TableRow key={product.id}>
+									<TableCell className="flex items-center gap-4">
+										<Image
+											src={product.images[0].src}
+											alt={product.images[0].alt}
+											width={50}
+											height={50}
+											className="rounded-lg"
+										/>
+										<span>{product.name}</span>
+									</TableCell>
+									<TableCell>{product.category}</TableCell>
+									<TableCell>${product.price}</TableCell>
+									<TableCell>
+										<div className="flex items-center gap-2">
+											<Button variant={"outline"} size={"icon"}>
+												<Eye />
+											</Button>
+											<Button variant={"outline"} size={"icon"}>
+												<SquarePen />
+											</Button>
+											<Button variant={"outline"} size={"icon"}>
+												<Trash2 />
+											</Button>
+										</div>
+									</TableCell>
+								</TableRow>
+							))
+						) : (
+							<TableRow>
+								<TableCell colSpan={4} className="text-center py-4">
+									No products found
+								</TableCell>
+							</TableRow>
+						)}
+					</TableBody>
+				</Table>
+			</div>
+		</section>
+	);
+}

--- a/apps/frontend/components/shared/header/user-menu.tsx
+++ b/apps/frontend/components/shared/header/user-menu.tsx
@@ -20,6 +20,7 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { Switch } from "@/components/ui/switch";
 import { useTranslations } from "@/hooks/useTranslations";
+import Link from "next/link";
 import { Tooltip, TooltipContent, TooltipTrigger } from "../../ui/tooltip";
 import { LanguageSelector } from "./language-selector";
 
@@ -47,8 +48,10 @@ export const UserMenu = () => {
 								<span>{t("common.profile")}</span>
 							</DropdownMenuItem>
 							<DropdownMenuItem>
-								<List className="mr-2 h-4 w-4" />
-								<span>{t("common.myProducts")}</span>
+								<Link href="/my-products" className="flex items-center gap-2">
+									<List className="mr-2 h-4 w-4" />
+									<span>{t("common.myProducts")}</span>
+								</Link>
 							</DropdownMenuItem>
 							<DropdownMenuItem>
 								<Receipt className="mr-2 h-4 w-4" />

--- a/apps/frontend/components/ui/table.tsx
+++ b/apps/frontend/components/ui/table.tsx
@@ -1,0 +1,120 @@
+import * as React from "react";
+
+import { cn } from "@/utils/cn";
+
+const Table = React.forwardRef<
+	HTMLTableElement,
+	React.HTMLAttributes<HTMLTableElement>
+>(({ className, ...props }, ref) => (
+	<div className="relative w-full overflow-auto">
+		<table
+			ref={ref}
+			className={cn("w-full caption-bottom text-sm", className)}
+			{...props}
+		/>
+	</div>
+));
+Table.displayName = "Table";
+
+const TableHeader = React.forwardRef<
+	HTMLTableSectionElement,
+	React.HTMLAttributes<HTMLTableSectionElement>
+>(({ className, ...props }, ref) => (
+	<thead ref={ref} className={cn("[&_tr]:border-b", className)} {...props} />
+));
+TableHeader.displayName = "TableHeader";
+
+const TableBody = React.forwardRef<
+	HTMLTableSectionElement,
+	React.HTMLAttributes<HTMLTableSectionElement>
+>(({ className, ...props }, ref) => (
+	<tbody
+		ref={ref}
+		className={cn("[&_tr:last-child]:border-0", className)}
+		{...props}
+	/>
+));
+TableBody.displayName = "TableBody";
+
+const TableFooter = React.forwardRef<
+	HTMLTableSectionElement,
+	React.HTMLAttributes<HTMLTableSectionElement>
+>(({ className, ...props }, ref) => (
+	<tfoot
+		ref={ref}
+		className={cn(
+			"border-t bg-muted/50 font-medium [&>tr]:last:border-b-0",
+			className,
+		)}
+		{...props}
+	/>
+));
+TableFooter.displayName = "TableFooter";
+
+const TableRow = React.forwardRef<
+	HTMLTableRowElement,
+	React.HTMLAttributes<HTMLTableRowElement>
+>(({ className, ...props }, ref) => (
+	<tr
+		ref={ref}
+		className={cn(
+			"border-b transition-colors hover:bg-muted/50 data-[state=selected]:bg-muted",
+			className,
+		)}
+		{...props}
+	/>
+));
+TableRow.displayName = "TableRow";
+
+const TableHead = React.forwardRef<
+	HTMLTableCellElement,
+	React.ThHTMLAttributes<HTMLTableCellElement>
+>(({ className, ...props }, ref) => (
+	<th
+		ref={ref}
+		className={cn(
+			"h-10 px-2 text-left align-middle font-medium text-muted-foreground [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
+			className,
+		)}
+		{...props}
+	/>
+));
+TableHead.displayName = "TableHead";
+
+const TableCell = React.forwardRef<
+	HTMLTableCellElement,
+	React.TdHTMLAttributes<HTMLTableCellElement>
+>(({ className, ...props }, ref) => (
+	<td
+		ref={ref}
+		className={cn(
+			"p-2 align-middle [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
+			className,
+		)}
+		{...props}
+	/>
+));
+TableCell.displayName = "TableCell";
+
+const TableCaption = React.forwardRef<
+	HTMLTableCaptionElement,
+	React.HTMLAttributes<HTMLTableCaptionElement>
+>(({ className, ...props }, ref) => (
+	<caption
+		ref={ref}
+		className={cn("mt-4 text-sm text-muted-foreground", className)}
+		{...props}
+	/>
+));
+TableCaption.displayName = "TableCaption";
+
+export {
+	Table,
+	TableHeader,
+	TableBody,
+	TableFooter,
+	TableHead,
+	TableRow,
+	TableCell,
+	TableCaption,
+};


### PR DESCRIPTION
# 📝 Create my products page

## 🛠️ Issue
- Closes #135 

## 📖 Description
This page allows users to manage and view the products they want to sell. It features a searchable and sortable table where users can:

✅ View product details, including an image, category, and price.
✅ Search for products by name or category using the input field.
✅ Sort products by name, category, or price by clicking on the column headers.

## ✅ Changes made
* Created a new folder called "my-products" in apps/frontend/app.
* Created a the "layout.tsx" in  apps/frontend/app/my-products
* Created a the "page.tsx" in  apps/frontend/app/my-products
* Updated the "user-menu.tsx" to handle the redirect to my products page
* Added the "table.tsx" component from [shadcn/ui](https://ui.shadcn.com/) in apps/frontend/components/ui 

## 🖼️ Media (screenshots/videos)
https://github.com/user-attachments/assets/015b2948-174e-4702-b2db-66c3f82b3ee9

