### PR TITLE
fix: href of product name

### DIFF
--- a/apps/frontend/app/marketplace/page.tsx
+++ b/apps/frontend/app/marketplace/page.tsx
@@ -119,7 +119,15 @@ export default function ProductList() {
 												`common.products.categories.${product.category.toLowerCase()}`,
 											)}
 										</p>
-										<Link href={`/marketplace/${product.id}`}>
+										<Link
+											href={`/marketplace/${generateProductSlug(
+												t(
+													`common.products.items.${getProductKey(
+														product.id,
+													)}.name`,
+												),
+											)}`}
+										>
 											<CardTitle className="text-xl font-medium cursor-pointer hover:underline pt-0">
 												{t(
 													`common.products.items.${getProductKey(


### PR DESCRIPTION
# 📝 Pull Request Title
Fix link on Product Name 

## 🛠️ Issue
- Closes #144 

## 📖 Description
- add this 
```ts
<Link
	href={`/marketplace/${generateProductSlug(
		t(
			`common.products.items.${getProductKey(
				product.id,
			)}.name`,
		),
	)
>
```

## ✅ Changes made
- 

## 🖼️ Media (screenshots/videos)
-

## 📜 Additional Notes
- 
