### PR TITLE
fix: update Jest config to handle absolute paths and resolve missing PrismaService in tests

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -62,7 +62,8 @@
 	},
 	"jest": {
 		"moduleFileExtensions": ["js", "json", "ts"],
-		"rootDir": "src",
+		"rootDir": "./",
+		"modulePaths": ["<rootDir>"],
 		"testRegex": ".*\\.spec\\.ts$",
 		"transform": {
 			"^.+\\.(t|j)s$": "ts-jest"

--- a/apps/backend/src/modules/categories/category.resolver.spec.ts
+++ b/apps/backend/src/modules/categories/category.resolver.spec.ts
@@ -1,4 +1,5 @@
 import { Test, TestingModule } from "@nestjs/testing";
+import { PrismaService } from "src/core/prisma/prisma.service";
 import { CategoryResolver } from "./category.resolver";
 import { CategoryService } from "./category.service";
 
@@ -7,7 +8,20 @@ describe("CategoryResolver", () => {
 
 	beforeEach(async () => {
 		const module: TestingModule = await Test.createTestingModule({
-			providers: [CategoryResolver, CategoryService],
+			providers: [
+				CategoryResolver,
+				CategoryService,
+				{
+					provide: PrismaService,
+					useValue: {
+						category: {
+							findMany: jest.fn(),
+							findUnique: jest.fn(),
+							create: jest.fn(),
+						},
+					},
+				},
+			],
 		}).compile();
 
 		resolver = module.get<CategoryResolver>(CategoryResolver);

--- a/apps/backend/src/modules/categories/category.service.spec.ts
+++ b/apps/backend/src/modules/categories/category.service.spec.ts
@@ -1,4 +1,5 @@
 import { Test, TestingModule } from "@nestjs/testing";
+import { PrismaService } from "src/core/prisma/prisma.service";
 import { CategoryService } from "./category.service";
 
 describe("CategoryService", () => {
@@ -6,7 +7,19 @@ describe("CategoryService", () => {
 
 	beforeEach(async () => {
 		const module: TestingModule = await Test.createTestingModule({
-			providers: [CategoryService],
+			providers: [
+				CategoryService,
+				{
+					provide: PrismaService,
+					useValue: {
+						category: {
+							findMany: jest.fn(),
+							findUnique: jest.fn(),
+							create: jest.fn(),
+						},
+					},
+				},
+			],
 		}).compile();
 
 		service = module.get<CategoryService>(CategoryService);

--- a/apps/backend/src/modules/product-image/product-image.resolver.spec.ts
+++ b/apps/backend/src/modules/product-image/product-image.resolver.spec.ts
@@ -1,4 +1,5 @@
 import { Test, TestingModule } from "@nestjs/testing";
+import { PrismaService } from "src/core/prisma/prisma.service";
 import { ProductImageResolver } from "./product-image.resolver";
 import { ProductImageService } from "./product-image.service";
 
@@ -7,7 +8,20 @@ describe("ProductImageResolver", () => {
 
 	beforeEach(async () => {
 		const module: TestingModule = await Test.createTestingModule({
-			providers: [ProductImageResolver, ProductImageService],
+			providers: [
+				ProductImageResolver,
+				ProductImageService,
+				{
+					provide: PrismaService,
+					useValue: {
+						productImage: {
+							findMany: jest.fn(),
+							findUnique: jest.fn(),
+							create: jest.fn(),
+						},
+					},
+				},
+			],
 		}).compile();
 
 		resolver = module.get<ProductImageResolver>(ProductImageResolver);

--- a/apps/backend/src/modules/product-image/product-image.service.spec.ts
+++ b/apps/backend/src/modules/product-image/product-image.service.spec.ts
@@ -1,4 +1,5 @@
 import { Test, TestingModule } from "@nestjs/testing";
+import { PrismaService } from "src/core/prisma/prisma.service";
 import { ProductImageService } from "./product-image.service";
 
 describe("ProductImageService", () => {
@@ -6,7 +7,19 @@ describe("ProductImageService", () => {
 
 	beforeEach(async () => {
 		const module: TestingModule = await Test.createTestingModule({
-			providers: [ProductImageService],
+			providers: [
+				ProductImageService,
+				{
+					provide: PrismaService,
+					useValue: {
+						productImage: {
+							findMany: jest.fn(),
+							findUnique: jest.fn(),
+							create: jest.fn(),
+						},
+					},
+				},
+			],
 		}).compile();
 
 		service = module.get<ProductImageService>(ProductImageService);


### PR DESCRIPTION
# 📝 Update Jest config to handle absolute paths and resolve missing PrismaService in tests

## 🛠️ Issue
- Closes #153 

## **📖 Description**

This PR fixes two issues in the test environment configuration:

1. Adjusts the Jest configuration to properly handle absolute paths.
2. Resolves an issue where **PrismaService** was not available in tests by ensuring it is correctly injected into the test module.

## **✅ Changes made**

- Updated `jest.config` to set `rootDir: "./"` and added `modulePaths: ["<rootDir>"]` to support absolute paths in Jest.
- Added **PrismaService** to the test modules can run without dependency injection errors.

## 🖼️ Media (screenshots/videos)

![image](https://github.com/user-attachments/assets/559a21d9-592a-4063-9f53-fc8654880227)

## 📜 Additional Notes
- 
