### PR TITLE
[FEAT]: Create "ready to become a seller" section

### DIFF
--- a/apps/frontend/app/page.tsx
+++ b/apps/frontend/app/page.tsx
@@ -2,6 +2,7 @@
 
 import { FeatureSection } from "@/components/home/feature-section";
 import { HeroSection } from "@/components/home/hero-section";
+import { SellerSection } from "@/components/home/seller-section";
 import { StatsSection } from "@/components/home/stats-section";
 
 export default function Home() {
@@ -10,6 +11,7 @@ export default function Home() {
 			<HeroSection />
 			<StatsSection />
 			<FeatureSection />
+			<SellerSection />
 		</main>
 	);
 }

--- a/apps/frontend/components/home/seller-section.tsx
+++ b/apps/frontend/components/home/seller-section.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { useTranslations } from "@/hooks/useTranslations";
+import Link from "next/link";
+export function SellerSection() {
+	const { t } = useTranslations();
+
+	return (
+		<div className="relative flex flex-col px-4 justify-center items-center bg-black/5 dark:bg-white/5  py-10 overflow-hidden">
+			<h2 className="text-3xl capitalize font-bold text-center mb-4">
+				{t("common.seller.title")}
+			</h2>
+			<p className="text-center text-muted-foreground mb-5 max-w-[600px] mx-auto">
+				{t("common.seller.description")}
+			</p>
+			<div className="relative max-w-6xl mx-auto px-4">
+				<Link href="/seller/onboarding">
+					<Button size="lg" className="group">
+						{t("common.seller.btn_label")}
+					</Button>
+				</Link>
+			</div>
+		</div>
+	);
+}

--- a/apps/frontend/locales/en.ts
+++ b/apps/frontend/locales/en.ts
@@ -171,7 +171,8 @@ export const en = {
 		},
 		seller: {
 			title: "Ready to start selling?",
-			description: "Join SafeSwap and reach thousands of buyers today!",
+			description:
+				"Join SafeSwap and reach thousands of potential buyers today!",
 			btn_label: "Become a seller",
 		},
 

--- a/apps/frontend/locales/en.ts
+++ b/apps/frontend/locales/en.ts
@@ -169,6 +169,11 @@ export const en = {
 				decrease: "Decrease quantity",
 			},
 		},
+		seller: {
+			title: "Ready to start selling?",
+			description: "Join SafeSwap and reach thousands of buyers today!",
+			btn_label: "Become a seller",
+		},
 
 		createProduct: {
 			title: "Sell Product",

--- a/apps/frontend/locales/es.ts
+++ b/apps/frontend/locales/es.ts
@@ -170,6 +170,12 @@ export const es = {
 				decrease: "Disminuir cantidad",
 			},
 		},
+		seller: {
+			title: "¿Listo para empezar a vender?",
+			description:
+				"¡Únete a SafeSwap y llega a miles de compradores hoy mismo!",
+			btn_label: "Conviértete en vendedor",
+		},
 
 		createProduct: {
 			title: "Vender Producto",


### PR DESCRIPTION
# 📝 [FEAT]: Create "ready to become a seller" section

## 🛠️ Issue
- Closes #159

## 📖 Description
- Added the become a seller section on the homepage

## ✅ Changes made
- added sellers-section component apps/frontend/components/home/seller-section.tsx
- added seller object translation to  apps\frontend\locales\es.ts and apps\frontend\locales\en.ts
- added seller-section component to home

## 🖼️ Media (screenshots/videos)
-mobile screen 
![mobile](https://github.com/user-attachments/assets/ca16168a-29a8-4e84-a3f3-54d000a48400)

- large screen 
![lg](https://github.com/user-attachments/assets/422250f9-539e-401e-abbc-aa59940db8b3)



## 📜 Additional Notes
- NA

