### PR TITLE
Test/product image

### DIFF
--- a/apps/backend/src/core/graphql/schema.gql
+++ b/apps/backend/src/core/graphql/schema.gql
@@ -3,23 +3,23 @@
 # ------------------------------------------------------
 
 type Category {
-  createdAt: DateTime!
-  id: ID!
-  imageUrl: String
-  name: String!
-  updatedAt: DateTime!
+	createdAt: DateTime!
+	id: ID!
+	imageUrl: String
+	name: String!
+	updatedAt: DateTime!
 }
 
 input CreateCategoryInput {
-  name: String!
+	name: String!
 }
 
 input CreateProductInput {
-  categoryId: String!
-  description: String
-  name: String!
-  price: Float!
-  slug: String!
+	categoryId: String!
+	description: String
+	name: String!
+	price: Float!
+	slug: String!
 }
 
 """
@@ -28,40 +28,40 @@ A date-time string at UTC, such as 2019-12-03T09:54:33Z, compliant with the date
 scalar DateTime
 
 type Mutation {
-  createCategory(data: CreateCategoryInput!): Category!
-  createProduct(data: CreateProductInput!): ProductDTO!
-  createProductImage(createProductImage: ProductImageDTO!): ProductImage!
+	createCategory(data: CreateCategoryInput!): Category!
+	createProduct(data: CreateProductInput!): ProductDTO!
+	createProductImage(createProductImage: ProductImageDTO!): ProductImage!
 }
 
 type ProductDTO {
-  categoryId: String!
-  createdAt: DateTime!
-  description: String
-  id: ID!
-  name: String!
-  price: Float!
-  slug: String!
-  updatedAt: DateTime!
+	categoryId: String!
+	createdAt: DateTime!
+	description: String
+	id: ID!
+	name: String!
+	price: Float!
+	slug: String!
+	updatedAt: DateTime!
 }
 
 type ProductImage {
-  createdAt: DateTime!
-  id: ID!
-  imageUrl: String!
-  productId: String!
-  updatedAt: DateTime!
+	createdAt: DateTime!
+	id: ID!
+	imageUrl: String!
+	productId: String!
+	updatedAt: DateTime!
 }
 
 input ProductImageDTO {
-  imageUrl: String!
-  productId: String!
+	imageUrl: String!
+	productId: String!
 }
 
 type Query {
-  categories: [Category!]!
-  category(id: String!): Category
-  product(id: String!): ProductDTO
-  productImage(id: String!): ProductImage
-  productImages: [ProductImage!]!
-  products: [ProductDTO!]!
+	categories: [Category!]!
+	category(id: String!): Category
+	product(id: String!): ProductDTO
+	productImage(id: String!): ProductImage
+	productImages: [ProductImage!]!
+	products: [ProductDTO!]!
 }

--- a/apps/backend/src/modules/product-image/product-image.resolver.spec.ts
+++ b/apps/backend/src/modules/product-image/product-image.resolver.spec.ts
@@ -1,95 +1,93 @@
 import { Test, TestingModule } from "@nestjs/testing";
 import { PrismaService } from "src/core/prisma/prisma.service";
-import { ProductImageResolver } from "./product-image.resolver";
 import { ProductImageDTO } from "./dto/product-image.input";
 import { ProductImage } from "./entities/product-image.entity";
+import { ProductImageResolver } from "./product-image.resolver";
 import { ProductImageService } from "./product-image.service";
 
 describe("ProductImageResolver", () => {
-  let resolver: ProductImageResolver;
-  let service: ProductImageService;
+	let resolver: ProductImageResolver;
 
-  const mockProductImageService = {
-    createProductImage: jest.fn(),
-    getAllProductImages: jest.fn(),
-    getAProductImage: jest.fn(),
-  };
+	const mockProductImageService = {
+		createProductImage: jest.fn(),
+		getAllProductImages: jest.fn(),
+		getAProductImage: jest.fn(),
+	};
 
-  beforeEach(async () => {
-    const module: TestingModule = await Test.createTestingModule({
-      providers: [
-        ProductImageResolver,
-        ProductImageService,
-        {
-          provide: ProductImageService,
-          useValue: mockProductImageService,
-        },
-      ],
-    }).compile();
+	beforeEach(async () => {
+		const module: TestingModule = await Test.createTestingModule({
+			providers: [
+				ProductImageResolver,
+				ProductImageService,
+				{
+					provide: ProductImageService,
+					useValue: mockProductImageService,
+				},
+			],
+		}).compile();
 
-    resolver = module.get<ProductImageResolver>(ProductImageResolver);
-    service = module.get<ProductImageService>(ProductImageService);
-  });
+		resolver = module.get<ProductImageResolver>(ProductImageResolver);
+	});
 
-  it("should be defined", () => {
-    expect(resolver).toBeDefined();
-  });
+	it("should be defined", () => {
+		expect(resolver).toBeDefined();
+	});
 
-  it("should create a product image", async () => {
-    const data: ProductImageDTO = {
-      imageUrl: "http://image.com",
-      productId: "1",
-    };
+	it("should create a product image", async () => {
+		const data: ProductImageDTO = {
+			imageUrl: "http://image.com",
+			productId: "1",
+		};
 
-    const createdImage = {
-      id: "1",
-      ...data,
-    };
+		const createdImage = {
+			id: "1",
+			...data,
+		};
 
-    mockProductImageService.createProductImage.mockReturnValue(createdImage);
+		mockProductImageService.createProductImage.mockReturnValue(createdImage);
 
-    const result = await resolver.createProductImage(data);
+		const result = await resolver.createProductImage(data);
 
-    expect(mockProductImageService.createProductImage).toHaveBeenCalled();
-    expect(mockProductImageService.createProductImage).toHaveBeenCalledWith(
-      data
-    );
+		expect(mockProductImageService.createProductImage).toHaveBeenCalled();
+		expect(mockProductImageService.createProductImage).toHaveBeenCalledWith(
+			data,
+		);
 
-    expect(result).toEqual(createdImage);
-  });
+		expect(result).toEqual(createdImage);
+	});
 
-  it("should return an array of all product images", async () => {
-    const productImages = [
-      {
-        id: "1",
-        imageUrl: "http://image.com",
-        productId: "1",
-      },
-    ];
+	it("should return an array of all product images", async () => {
+		const productImages = [
+			{
+				id: "1",
+				imageUrl: "http://image.com",
+				productId: "1",
+			},
+		];
 
-    mockProductImageService.getAllProductImages.mockReturnValue(productImages);
+		mockProductImageService.getAllProductImages.mockReturnValue(productImages);
 
-    const result = await resolver.productImages();
+		const result = await resolver.productImages();
 
-    expect(mockProductImageService.getAllProductImages).toHaveBeenCalled();
+		expect(mockProductImageService.getAllProductImages).toHaveBeenCalled();
 
-    expect(result).toEqual(productImages);
-  });
+		expect(result).toEqual(productImages);
+	});
 
-  it("should return a product image", async () => {
-    const productImage = {
-      id: "1",
-      imageUrl: "http://image.com",
-      productId: "1",
-    };
+	it("should return a product image", async () => {
+		const productImage = {
+			id: "1",
+			imageUrl: "http://image.com",
+			productId: "1",
+		};
 
-    mockProductImageService.getAProductImage.mockReturnValue(productImage);
+		mockProductImageService.getAProductImage.mockReturnValue(productImage);
 
-    const result = await resolver.productImage("1");
+		const result = await resolver.productImage("1");
 
-    expect(mockProductImageService.getAProductImage).toHaveBeenCalled();
-    expect(mockProductImageService.getAProductImage).toHaveBeenCalledWith("1");
+		expect(mockProductImageService.getAProductImage).toHaveBeenCalled();
+		expect(mockProductImageService.getAProductImage).toHaveBeenCalledWith("1");
 
-    expect(result).toEqual(productImage);
-  });
+		expect(result).toEqual(productImage);
+	});
 });

--- a/apps/backend/src/modules/product-image/product-image.resolver.spec.ts
+++ b/apps/backend/src/modules/product-image/product-image.resolver.spec.ts
@@ -1,33 +1,93 @@
 import { Test, TestingModule } from "@nestjs/testing";
 import { PrismaService } from "src/core/prisma/prisma.service";
 import { ProductImageResolver } from "./product-image.resolver";
+import { ProductImageDTO } from "./dto/product-image.input";
+import { ProductImage } from "./entities/product-image.entity";
 import { ProductImageService } from "./product-image.service";
 
 describe("ProductImageResolver", () => {
 	let resolver: ProductImageResolver;
+	let service: ProductImageService;
+
+	const mockProductImageService = {
+			createProductImage: jest.fn(),
+			getAllProductImages: jest.fn(),
+			getAProductImage: jest.fn(),
+	};
 
 	beforeEach(async () => {
 		const module: TestingModule = await Test.createTestingModule({
-			providers: [
-				ProductImageResolver,
-				ProductImageService,
-				{
-					provide: PrismaService,
-					useValue: {
-						productImage: {
-							findMany: jest.fn(),
-							findUnique: jest.fn(),
-							create: jest.fn(),
-						},
-					},
-				},
-			],
-		}).compile();
+      providers: [
+        ProductImageResolver,
+        ProductImageService,
+        {
+          provide: ProductImageService,
+          useValue: mockProductImageService,
+        },
+      ],
+    }).compile();
 
 		resolver = module.get<ProductImageResolver>(ProductImageResolver);
+		service = module.get<ProductImageService>(ProductImageService);
 	});
 
 	it("should be defined", () => {
 		expect(resolver).toBeDefined();
+	});
+
+	it("should create a product image", async () => {
+		const data: ProductImageDTO = {
+			imageUrl: "http://image.com",
+			productId: "1",
+		};
+
+		const createdImage = {
+			id: "1",
+			...data,
+		};
+
+		mockProductImageService.createProductImage.mockReturnValue(createdImage);
+
+		const result = await resolver.createProductImage(data);
+
+		expect(mockProductImageService.createProductImage).toHaveBeenCalled();
+		expect(mockProductImageService.createProductImage).toHaveBeenCalledWith(data);
+
+		expect(result).toEqual(createdImage);
+	});
+
+	it("should return an array of all product images", async () => {
+		const productImages = [
+			{
+				id: "1",
+				imageUrl: "http://image.com",
+				productId: "1",
+			},
+		];
+
+		mockProductImageService.getAllProductImages.mockReturnValue(productImages);
+
+		const result = await resolver.productImages();
+
+		expect(mockProductImageService.getAllProductImages).toHaveBeenCalled();
+
+		expect(result).toEqual(productImages);
+	});
+
+	it("should return a product image", async () => {
+		const productImage = {
+			id: "1",
+			imageUrl: "http://image.com",
+			productId: "1",
+		};
+
+		mockProductImageService.getAProductImage.mockReturnValue(productImage);
+
+		const result = await resolver.productImage("1");
+
+		expect(mockProductImageService.getAProductImage).toHaveBeenCalled();
+		expect(mockProductImageService.getAProductImage).toHaveBeenCalledWith("1");
+
+		expect(result).toEqual(productImage);
 	});
 });

--- a/apps/backend/src/modules/product-image/product-image.resolver.spec.ts
+++ b/apps/backend/src/modules/product-image/product-image.resolver.spec.ts
@@ -6,17 +6,17 @@ import { ProductImage } from "./entities/product-image.entity";
 import { ProductImageService } from "./product-image.service";
 
 describe("ProductImageResolver", () => {
-	let resolver: ProductImageResolver;
-	let service: ProductImageService;
+  let resolver: ProductImageResolver;
+  let service: ProductImageService;
 
-	const mockProductImageService = {
-			createProductImage: jest.fn(),
-			getAllProductImages: jest.fn(),
-			getAProductImage: jest.fn(),
-	};
+  const mockProductImageService = {
+    createProductImage: jest.fn(),
+    getAllProductImages: jest.fn(),
+    getAProductImage: jest.fn(),
+  };
 
-	beforeEach(async () => {
-		const module: TestingModule = await Test.createTestingModule({
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
       providers: [
         ProductImageResolver,
         ProductImageService,
@@ -27,67 +27,69 @@ describe("ProductImageResolver", () => {
       ],
     }).compile();
 
-		resolver = module.get<ProductImageResolver>(ProductImageResolver);
-		service = module.get<ProductImageService>(ProductImageService);
-	});
+    resolver = module.get<ProductImageResolver>(ProductImageResolver);
+    service = module.get<ProductImageService>(ProductImageService);
+  });
 
-	it("should be defined", () => {
-		expect(resolver).toBeDefined();
-	});
+  it("should be defined", () => {
+    expect(resolver).toBeDefined();
+  });
 
-	it("should create a product image", async () => {
-		const data: ProductImageDTO = {
-			imageUrl: "http://image.com",
-			productId: "1",
-		};
+  it("should create a product image", async () => {
+    const data: ProductImageDTO = {
+      imageUrl: "http://image.com",
+      productId: "1",
+    };
 
-		const createdImage = {
-			id: "1",
-			...data,
-		};
+    const createdImage = {
+      id: "1",
+      ...data,
+    };
 
-		mockProductImageService.createProductImage.mockReturnValue(createdImage);
+    mockProductImageService.createProductImage.mockReturnValue(createdImage);
 
-		const result = await resolver.createProductImage(data);
+    const result = await resolver.createProductImage(data);
 
-		expect(mockProductImageService.createProductImage).toHaveBeenCalled();
-		expect(mockProductImageService.createProductImage).toHaveBeenCalledWith(data);
+    expect(mockProductImageService.createProductImage).toHaveBeenCalled();
+    expect(mockProductImageService.createProductImage).toHaveBeenCalledWith(
+      data
+    );
 
-		expect(result).toEqual(createdImage);
-	});
+    expect(result).toEqual(createdImage);
+  });
 
-	it("should return an array of all product images", async () => {
-		const productImages = [
-			{
-				id: "1",
-				imageUrl: "http://image.com",
-				productId: "1",
-			},
-		];
+  it("should return an array of all product images", async () => {
+    const productImages = [
+      {
+        id: "1",
+        imageUrl: "http://image.com",
+        productId: "1",
+      },
+    ];
 
-		mockProductImageService.getAllProductImages.mockReturnValue(productImages);
+    mockProductImageService.getAllProductImages.mockReturnValue(productImages);
 
-		const result = await resolver.productImages();
+    const result = await resolver.productImages();
 
-		expect(mockProductImageService.getAllProductImages).toHaveBeenCalled();
+    expect(mockProductImageService.getAllProductImages).toHaveBeenCalled();
 
-		expect(result).toEqual(productImages);
-	});
+    expect(result).toEqual(productImages);
+  });
 
-	it("should return a product image", async () => {
-		const productImage = {
-			id: "1",
-			imageUrl: "http://image.com",
-			productId: "1",
-		};
+  it("should return a product image", async () => {
+    const productImage = {
+      id: "1",
+      imageUrl: "http://image.com",
+      productId: "1",
+    };
 
-		mockProductImageService.getAProductImage.mockReturnValue(productImage);
+    mockProductImageService.getAProductImage.mockReturnValue(productImage);
 
-		const result = await resolver.productImage("1");
+    const result = await resolver.productImage("1");
 
-		expect(mockProductImageService.getAProductImage).toHaveBeenCalled();
-		expect(mockProductImageService.getAProductImage).toHaveBeenCalledWith("1");
+    expect(mockProductImageService.getAProductImage).toHaveBeenCalled();
+    expect(mockProductImageService.getAProductImage).toHaveBeenCalledWith("1");
 
-		expect(result).toEqual(productImage);
-	});
+    expect(result).toEqual(productImage);
+  });
 });

--- a/apps/backend/src/modules/product-image/product-image.service.spec.ts
+++ b/apps/backend/src/modules/product-image/product-image.service.spec.ts
@@ -8,11 +8,11 @@ describe("ProductImageService", () => {
   let prisma: PrismaService;
 
   const mockPrismaService = {
-		productImage: {
-			create: jest.fn(),
-			findMany: jest.fn(),
-			findUnique: jest.fn(),
-		}
+    productImage: {
+      create: jest.fn(),
+      findMany: jest.fn(),
+      findUnique: jest.fn(),
+    },
   };
 
   beforeEach(async () => {
@@ -49,8 +49,10 @@ describe("ProductImageService", () => {
 
     const result = await service.createProductImage(data);
 
-		expect(mockPrismaService.productImage.create).toHaveBeenCalled();
-		expect(mockPrismaService.productImage.create).toHaveBeenCalledWith({ data });
+    expect(mockPrismaService.productImage.create).toHaveBeenCalled();
+    expect(mockPrismaService.productImage.create).toHaveBeenCalledWith({
+      data,
+    });
 
     expect(result).toEqual(createdImage);
   });
@@ -69,20 +71,20 @@ describe("ProductImageService", () => {
     const result = await service.getAllProductImages();
 
     expect(result).toEqual(productImages);
-		expect(mockPrismaService.productImage.findMany).toHaveBeenCalled();
+    expect(mockPrismaService.productImage.findMany).toHaveBeenCalled();
   });
 
-	it("should return an empty array if no product images are found", async () => {
-		mockPrismaService.productImage.findMany.mockReturnValue([]);
+  it("should return an empty array if no product images are found", async () => {
+    mockPrismaService.productImage.findMany.mockReturnValue([]);
 
-		const result = await service.getAllProductImages();
+    const result = await service.getAllProductImages();
 
-		expect (result).toEqual([]);
-		expect(mockPrismaService.productImage.findMany).toHaveBeenCalled();
-	})
+    expect(result).toEqual([]);
+    expect(mockPrismaService.productImage.findMany).toHaveBeenCalled();
+  });
 
   it("should get a product image", async () => {
-		const id = "1";
+    const id = "1";
     const data = {
       id: "1",
       imageUrl: "http://image.com",
@@ -94,17 +96,23 @@ describe("ProductImageService", () => {
     const result = await service.getAProductImage(id);
 
     expect(result).toEqual(data);
-		expect(mockPrismaService.productImage.findUnique).toHaveBeenCalled();
-		expect(mockPrismaService.productImage.findUnique).toHaveBeenCalledWith({ where: { id } });
+    expect(mockPrismaService.productImage.findUnique).toHaveBeenCalled();
+    expect(mockPrismaService.productImage.findUnique).toHaveBeenCalledWith({
+      where: { id },
+    });
   });
 
-	it("should throw an error if product image is not found", async () => {
-		const id = "1";
+  it("should throw an error if product image is not found", async () => {
+    const id = "1";
 
-		mockPrismaService.productImage.findUnique.mockReturnValue(null);
+    mockPrismaService.productImage.findUnique.mockReturnValue(null);
 
-		await expect(service.getAProductImage(id)).rejects.toThrow("Product image not found.");
-		expect(mockPrismaService.productImage.findUnique).toHaveBeenCalled();
-		expect(mockPrismaService.productImage.findUnique).toHaveBeenCalledWith({ where: { id } });
-	});
+    await expect(service.getAProductImage(id)).rejects.toThrow(
+      "Product image not found."
+    );
+    expect(mockPrismaService.productImage.findUnique).toHaveBeenCalled();
+    expect(mockPrismaService.productImage.findUnique).toHaveBeenCalledWith({
+      where: { id },
+    });
+  });
 });

--- a/apps/backend/src/modules/product-image/product-image.service.spec.ts
+++ b/apps/backend/src/modules/product-image/product-image.service.spec.ts
@@ -1,118 +1,116 @@
 import { Test, TestingModule } from "@nestjs/testing";
 import { PrismaService } from "src/core/prisma/prisma.service";
-import { ProductImageService } from "./product-image.service";
 import { ProductImageDTO } from "./dto/product-image.input";
+import { ProductImageService } from "./product-image.service";
 
 describe("ProductImageService", () => {
-  let service: ProductImageService;
-  let prisma: PrismaService;
+	let service: ProductImageService;
 
-  const mockPrismaService = {
-    productImage: {
-      create: jest.fn(),
-      findMany: jest.fn(),
-      findUnique: jest.fn(),
-    },
-  };
+	const mockPrismaService = {
+		productImage: {
+			create: jest.fn(),
+			findMany: jest.fn(),
+			findUnique: jest.fn(),
+		},
+	};
 
-  beforeEach(async () => {
-    const module: TestingModule = await Test.createTestingModule({
-      providers: [
-        ProductImageService,
-        {
-          provide: PrismaService,
-          useValue: mockPrismaService,
-        },
-      ],
-    }).compile();
+	beforeEach(async () => {
+		const module: TestingModule = await Test.createTestingModule({
+			providers: [
+				ProductImageService,
+				{
+					provide: PrismaService,
+					useValue: mockPrismaService,
+				},
+			],
+		}).compile();
 
-    service = module.get<ProductImageService>(ProductImageService);
-    prisma = module.get<PrismaService>(PrismaService);
-  });
+		service = module.get<ProductImageService>(ProductImageService);
+	});
 
-  it("should be defined", () => {
-    expect(service).toBeDefined();
-  });
+	it("should be defined", () => {
+		expect(service).toBeDefined();
+	});
 
-  it("should create a product image", async () => {
-    const data: ProductImageDTO = {
-      imageUrl: "http://image.com",
-      productId: "1",
-    };
+	it("should create a product image", async () => {
+		const data: ProductImageDTO = {
+			imageUrl: "http://image.com",
+			productId: "1",
+		};
 
-    const createdImage = {
-      id: "1",
-      ...data,
-    };
+		const createdImage = {
+			id: "1",
+			...data,
+		};
 
-    mockPrismaService.productImage.create.mockReturnValue(createdImage);
+		mockPrismaService.productImage.create.mockReturnValue(createdImage);
 
-    const result = await service.createProductImage(data);
+		const result = await service.createProductImage(data);
 
-    expect(mockPrismaService.productImage.create).toHaveBeenCalled();
-    expect(mockPrismaService.productImage.create).toHaveBeenCalledWith({
-      data,
-    });
+		expect(mockPrismaService.productImage.create).toHaveBeenCalled();
+		expect(mockPrismaService.productImage.create).toHaveBeenCalledWith({
+			data,
+		});
 
-    expect(result).toEqual(createdImage);
-  });
+		expect(result).toEqual(createdImage);
+	});
 
-  it("should return an array of all product images", async () => {
-    const productImages = [
-      {
-        id: "1",
-        imageUrl: "http://image.com",
-        productId: "1",
-      },
-    ];
+	it("should return an array of all product images", async () => {
+		const productImages = [
+			{
+				id: "1",
+				imageUrl: "http://image.com",
+				productId: "1",
+			},
+		];
 
-    mockPrismaService.productImage.findMany.mockReturnValue(productImages);
+		mockPrismaService.productImage.findMany.mockReturnValue(productImages);
 
-    const result = await service.getAllProductImages();
+		const result = await service.getAllProductImages();
 
-    expect(result).toEqual(productImages);
-    expect(mockPrismaService.productImage.findMany).toHaveBeenCalled();
-  });
+		expect(result).toEqual(productImages);
+		expect(mockPrismaService.productImage.findMany).toHaveBeenCalled();
+	});
 
-  it("should return an empty array if no product images are found", async () => {
-    mockPrismaService.productImage.findMany.mockReturnValue([]);
+	it("should return an empty array if no product images are found", async () => {
+		mockPrismaService.productImage.findMany.mockReturnValue([]);
 
-    const result = await service.getAllProductImages();
+		const result = await service.getAllProductImages();
 
-    expect(result).toEqual([]);
-    expect(mockPrismaService.productImage.findMany).toHaveBeenCalled();
-  });
+		expect(result).toEqual([]);
+		expect(mockPrismaService.productImage.findMany).toHaveBeenCalled();
+	});
 
-  it("should get a product image", async () => {
-    const id = "1";
-    const data = {
-      id: "1",
-      imageUrl: "http://image.com",
-      productId: "1",
-    };
+	it("should get a product image", async () => {
+		const id = "1";
+		const data = {
+			id: "1",
+			imageUrl: "http://image.com",
+			productId: "1",
+		};
 
-    mockPrismaService.productImage.findUnique.mockReturnValue(data);
+		mockPrismaService.productImage.findUnique.mockReturnValue(data);
 
-    const result = await service.getAProductImage(id);
+		const result = await service.getAProductImage(id);
 
-    expect(result).toEqual(data);
-    expect(mockPrismaService.productImage.findUnique).toHaveBeenCalled();
-    expect(mockPrismaService.productImage.findUnique).toHaveBeenCalledWith({
-      where: { id },
-    });
-  });
+		expect(result).toEqual(data);
+		expect(mockPrismaService.productImage.findUnique).toHaveBeenCalled();
+		expect(mockPrismaService.productImage.findUnique).toHaveBeenCalledWith({
+			where: { id },
+		});
+	});
 
-  it("should throw an error if product image is not found", async () => {
-    const id = "1";
+	it("should throw an error if product image is not found", async () => {
+		const id = "1";
 
-    mockPrismaService.productImage.findUnique.mockReturnValue(null);
+		mockPrismaService.productImage.findUnique.mockReturnValue(null);
 
-    await expect(service.getAProductImage(id)).rejects.toThrow(
-      "Product image not found."
-    );
-    expect(mockPrismaService.productImage.findUnique).toHaveBeenCalled();
-    expect(mockPrismaService.productImage.findUnique).toHaveBeenCalledWith({
-      where: { id },
-    });
-  });
+		await expect(service.getAProductImage(id)).rejects.toThrow(
+			"Product image not found.",
+		);
+		expect(mockPrismaService.productImage.findUnique).toHaveBeenCalled();
+		expect(mockPrismaService.productImage.findUnique).toHaveBeenCalledWith({
+			where: { id },
+		});
+	});
 });

--- a/apps/backend/src/modules/product-image/product-image.service.spec.ts
+++ b/apps/backend/src/modules/product-image/product-image.service.spec.ts
@@ -1,31 +1,110 @@
 import { Test, TestingModule } from "@nestjs/testing";
 import { PrismaService } from "src/core/prisma/prisma.service";
 import { ProductImageService } from "./product-image.service";
+import { ProductImageDTO } from "./dto/product-image.input";
 
 describe("ProductImageService", () => {
-	let service: ProductImageService;
+  let service: ProductImageService;
+  let prisma: PrismaService;
 
-	beforeEach(async () => {
-		const module: TestingModule = await Test.createTestingModule({
-			providers: [
-				ProductImageService,
-				{
-					provide: PrismaService,
-					useValue: {
-						productImage: {
-							findMany: jest.fn(),
-							findUnique: jest.fn(),
-							create: jest.fn(),
-						},
-					},
-				},
-			],
-		}).compile();
+  const mockPrismaService = {
+		productImage: {
+			create: jest.fn(),
+			findMany: jest.fn(),
+			findUnique: jest.fn(),
+		}
+  };
 
-		service = module.get<ProductImageService>(ProductImageService);
-	});
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ProductImageService,
+        {
+          provide: PrismaService,
+          useValue: mockPrismaService,
+        },
+      ],
+    }).compile();
 
-	it("should be defined", () => {
-		expect(service).toBeDefined();
+    service = module.get<ProductImageService>(ProductImageService);
+    prisma = module.get<PrismaService>(PrismaService);
+  });
+
+  it("should be defined", () => {
+    expect(service).toBeDefined();
+  });
+
+  it("should create a product image", async () => {
+    const data: ProductImageDTO = {
+      imageUrl: "http://image.com",
+      productId: "1",
+    };
+
+    const createdImage = {
+      id: "1",
+      ...data,
+    };
+
+    mockPrismaService.productImage.create.mockReturnValue(createdImage);
+
+    const result = await service.createProductImage(data);
+
+		expect(mockPrismaService.productImage.create).toHaveBeenCalled();
+		expect(mockPrismaService.productImage.create).toHaveBeenCalledWith({ data });
+
+    expect(result).toEqual(createdImage);
+  });
+
+  it("should return an array of all product images", async () => {
+    const productImages = [
+      {
+        id: "1",
+        imageUrl: "http://image.com",
+        productId: "1",
+      },
+    ];
+
+    mockPrismaService.productImage.findMany.mockReturnValue(productImages);
+
+    const result = await service.getAllProductImages();
+
+    expect(result).toEqual(productImages);
+		expect(mockPrismaService.productImage.findMany).toHaveBeenCalled();
+  });
+
+	it("should return an empty array if no product images are found", async () => {
+		mockPrismaService.productImage.findMany.mockReturnValue([]);
+
+		const result = await service.getAllProductImages();
+
+		expect (result).toEqual([]);
+		expect(mockPrismaService.productImage.findMany).toHaveBeenCalled();
+	})
+
+  it("should get a product image", async () => {
+		const id = "1";
+    const data = {
+      id: "1",
+      imageUrl: "http://image.com",
+      productId: "1",
+    };
+
+    mockPrismaService.productImage.findUnique.mockReturnValue(data);
+
+    const result = await service.getAProductImage(id);
+
+    expect(result).toEqual(data);
+		expect(mockPrismaService.productImage.findUnique).toHaveBeenCalled();
+		expect(mockPrismaService.productImage.findUnique).toHaveBeenCalledWith({ where: { id } });
+  });
+
+	it("should throw an error if product image is not found", async () => {
+		const id = "1";
+
+		mockPrismaService.productImage.findUnique.mockReturnValue(null);
+
+		await expect(service.getAProductImage(id)).rejects.toThrow("Product image not found.");
+		expect(mockPrismaService.productImage.findUnique).toHaveBeenCalled();
+		expect(mockPrismaService.productImage.findUnique).toHaveBeenCalledWith({ where: { id } });
 	});
 });


### PR DESCRIPTION
# 📝 Added Unit Tests for Product Image Module

## 🛠️ Issue  
- Closes #169  

## 📖 Description  
This pull request adds unit tests for the `Product Image` Service and Resolver, ensuring high test coverage and validating the key functionalities of both the service and resolver.  
The following scenarios are covered:  
- Product image creation  
- Retrieving all product images  
- Fetching a single product image by ID  
- Handling empty results and missing product images  

## ✅ Changes Made  
- **Unit Tests for `ProductImageService` (`product-image.service.spec.ts`)**  
  - `createProductImage(data: ProductImageDTO)` — Tests successful creation of product images  
  - `getAllProductImages()` — Tests returning all product images, including an empty array scenario  
  - `getAProductImage(id: string)` — Tests fetching a product image by ID and handling not-found errors  

- **Unit Tests for `ProductImageResolver` (`product-image.resolver.spec.ts`)**  
  - `createProductImage(payload: ProductImageDTO)` — Tests the mutation for creating product images  
  - `productImages()` — Tests the query for retrieving all product images  
  - `productImage(id: string)` — Tests the query for fetching a single product image

- **Mocking and Dependency Injection**  
  - Mocked `PrismaService` for proper isolation of unit tests  
  - Ensured the resolver and service are correctly wired up in the testing module  

## 🖼️ Media (Screenshots/Videos)  
- ✅ **Test Run Output:**  
![Test results](https://github.com/user-attachments/assets/cdc7cd61-6d97-4f11-846d-050a6ef507c0)  

## 📜 Additional Notes  
- Current test coverage is near 100% for the `ProductImage` module  
- Edge cases and error handling have been thoroughly tested  
- Open to feedback on any additional scenarios that should be covered  