### PR TITLE
fix: show toast notification in the correct language after change

### DIFF
--- a/apps/frontend/components/shared/sidebar/language-selector.tsx
+++ b/apps/frontend/components/shared/sidebar/language-selector.tsx
@@ -2,7 +2,7 @@
 
 import { useLocale, useTranslations } from "next-intl";
 import Image from "next/image";
-import { useTransition } from "react";
+import { useEffect, useRef, useTransition } from "react";
 
 import { useToast } from "@/hooks/use-toast";
 import { Language } from "@/lib/i18n/config";
@@ -21,21 +21,26 @@ export const LanguageSelector = () => {
 	const { toast } = useToast();
 	const t = useTranslations();
 
+	const previousLocale = useRef(locale);
+
+	useEffect(() => {
+		if (locale !== previousLocale.current) {
+			toast({
+				description: t("sidebar.language.successMessage"),
+			});
+			previousLocale.current = locale;
+		}
+	}, [locale, toast, t]);
+
 	const handleChange = (newLang: Language) => {
 		startTransition(() => {
-			setLanguage(newLang)
-				.then(() => {
-					toast({
-						description: t("sidebar.language.successMessage"),
-					});
-				})
-				.catch((error) => {
-					console.log(error);
-					toast({
-						variant: "destructive",
-						description: t("sidebar.language.errorMessage"),
-					});
+			setLanguage(newLang).catch((error) => {
+				console.log(error);
+				toast({
+					variant: "destructive",
+					description: t("sidebar.language.errorMessage"),
 				});
+			});
 		});
 	};
 


### PR DESCRIPTION
# 📝 Show Toast Notification in the correct Language

## 🛠️ Issue
- Closes #issue-ID

## 📖 Description

This PR fixes the issue where toast notifications were displayed in the **previous language** instead of the newly selected one.

The update ensures that the toast message appears **only after the language change has been fully applied** in `next-intl`.

## ✅ Changes made

- Added a **`useEffect` hook** to detect when `locale` has actually changed before showing the toast.
- Implemented **`useRef(previousLocale)`** to prevent unnecessary toast executions.

## 🖼️ Media (screenshots/videos)

![image](https://github.com/user-attachments/assets/299de139-9bdf-4c22-b8cf-bb895261116c)

## 📜 Additional Notes
- 
