### PR TITLE
[FEAT]: Integrate Sales Metrics Charts in Sales Dashboard

### DIFF
--- a/apps/frontend/app/(routes)/seller/sales/page.tsx
+++ b/apps/frontend/app/(routes)/seller/sales/page.tsx
@@ -5,7 +5,7 @@ import { SalesAnalyticsHeader } from "@/components/seller/ui/pages/analytics/Sal
 
 export default function SalesPage() {
 	return (
-		<div className="container space-y-8 py-8">
+		<div className="container mx-auto px-4 sm:px-6 lg:px-8 space-y-8 py-4 sm:py-8 max-w-[100vw] overflow-x-hidden">
 			<SalesAnalyticsHeader />
 			<SalesAnalytics />
 			<SalesHeader />

--- a/apps/frontend/app/(routes)/seller/sales/page.tsx
+++ b/apps/frontend/app/(routes)/seller/sales/page.tsx
@@ -1,9 +1,13 @@
 import { SalesHeader } from "@/components/seller/ui/pages/SalesHeader";
 import { SalesTable } from "@/components/seller/ui/pages/SalesTable";
+import { SalesAnalytics } from "@/components/seller/ui/pages/analytics/SalesAnalytics";
+import { SalesAnalyticsHeader } from "@/components/seller/ui/pages/analytics/SalesAnalyticsHeader";
 
 export default function SalesPage() {
 	return (
-		<div className="container space-y-2">
+		<div className="container space-y-8 py-8">
+			<SalesAnalyticsHeader />
+			<SalesAnalytics />
 			<SalesHeader />
 			<SalesTable />
 		</div>

--- a/apps/frontend/components/seller/mock/sales-analytics.mock.ts
+++ b/apps/frontend/components/seller/mock/sales-analytics.mock.ts
@@ -44,10 +44,10 @@ export const mockSalesData: Record<TimeRange, SalesAnalytics> = {
 			sales: Math.floor(Math.random() * 500) + 200,
 		})),
 		categorySales: [
-			{ name: "Electronics", value: 45, color: "emerald" },
-			{ name: "Clothing", value: 15, color: "coral" },
-			{ name: "Home", value: 22, color: "slate" },
-			{ name: "Other", value: 18, color: "amber" },
+			{ name: "Electronics", value: 42, color: "green" },
+			{ name: "Clothing", value: 14, color: "orange" },
+			{ name: "Home", value: 25, color: "gray" },
+			{ name: "Other", value: 19, color: "gold" },
 		],
 	},
 	Yearly: {
@@ -59,10 +59,10 @@ export const mockSalesData: Record<TimeRange, SalesAnalytics> = {
 			sales: Math.floor(Math.random() * 15000) + 8000,
 		})),
 		categorySales: [
-			{ name: "Electronics", value: 40, color: "emerald" },
-			{ name: "Clothing", value: 18, color: "coral" },
-			{ name: "Home", value: 24, color: "slate" },
-			{ name: "Other", value: 18, color: "amber" },
+			{ name: "Electronics", value: 42, color: "green" },
+			{ name: "Clothing", value: 14, color: "orange" },
+			{ name: "Home", value: 25, color: "gray" },
+			{ name: "Other", value: 19, color: "gold" },
 		],
 	},
 	"All Time": {
@@ -76,10 +76,10 @@ export const mockSalesData: Record<TimeRange, SalesAnalytics> = {
 			sales: Math.floor(Math.random() * 25000) + 12000,
 		})),
 		categorySales: [
-			{ name: "Electronics", value: 38, color: "emerald" },
-			{ name: "Clothing", value: 20, color: "coral" },
-			{ name: "Home", value: 23, color: "slate" },
-			{ name: "Other", value: 19, color: "amber" },
+			{ name: "Electronics", value: 42, color: "green" },
+			{ name: "Clothing", value: 14, color: "orange" },
+			{ name: "Home", value: 25, color: "gray" },
+			{ name: "Other", value: 19, color: "gold" },
 		],
 	},
 };

--- a/apps/frontend/components/seller/mock/sales-analytics.mock.ts
+++ b/apps/frontend/components/seller/mock/sales-analytics.mock.ts
@@ -1,0 +1,85 @@
+export type TimeRange = "Monthly" | "Quarterly" | "Yearly" | "All Time";
+
+export interface SalesByDay {
+	date: string;
+	sales: number;
+}
+
+export interface CategorySales {
+	name: string;
+	value: number;
+	color: string;
+}
+
+export interface SalesAnalytics {
+	totalSales: number;
+	averageOrderValue: number;
+	totalOrders: number;
+	salesByDay: SalesByDay[];
+	categorySales: CategorySales[];
+}
+
+export const mockSalesData: Record<TimeRange, SalesAnalytics> = {
+	Monthly: {
+		totalSales: 10543,
+		averageOrderValue: 351,
+		totalOrders: 968,
+		salesByDay: Array.from({ length: 30 }, (_, i) => ({
+			date: `2024-03-${String(i + 1).padStart(2, "0")}`,
+			sales: Math.floor(Math.random() * 450) + 150,
+		})),
+		categorySales: [
+			{ name: "Electronics", value: 42, color: "green" },
+			{ name: "Clothing", value: 14, color: "orange" },
+			{ name: "Home", value: 25, color: "gray" },
+			{ name: "Other", value: 19, color: "gold" },
+		],
+	},
+	Quarterly: {
+		totalSales: 35250,
+		averageOrderValue: 375,
+		totalOrders: 2945,
+		salesByDay: Array.from({ length: 90 }, (_, i) => ({
+			date: new Date(2024, 0, i + 1).toISOString().split("T")[0],
+			sales: Math.floor(Math.random() * 500) + 200,
+		})),
+		categorySales: [
+			{ name: "Electronics", value: 45, color: "emerald" },
+			{ name: "Clothing", value: 15, color: "coral" },
+			{ name: "Home", value: 22, color: "slate" },
+			{ name: "Other", value: 18, color: "amber" },
+		],
+	},
+	Yearly: {
+		totalSales: 156780,
+		averageOrderValue: 385,
+		totalOrders: 12567,
+		salesByDay: Array.from({ length: 12 }, (_, i) => ({
+			date: new Date(2024, i, 1).toISOString().split("T")[0],
+			sales: Math.floor(Math.random() * 15000) + 8000,
+		})),
+		categorySales: [
+			{ name: "Electronics", value: 40, color: "emerald" },
+			{ name: "Clothing", value: 18, color: "coral" },
+			{ name: "Home", value: 24, color: "slate" },
+			{ name: "Other", value: 18, color: "amber" },
+		],
+	},
+	"All Time": {
+		totalSales: 458920,
+		averageOrderValue: 392,
+		totalOrders: 36789,
+		salesByDay: Array.from({ length: 24 }, (_, i) => ({
+			date: new Date(2022 + Math.floor(i / 12), i % 12, 1)
+				.toISOString()
+				.split("T")[0],
+			sales: Math.floor(Math.random() * 25000) + 12000,
+		})),
+		categorySales: [
+			{ name: "Electronics", value: 38, color: "emerald" },
+			{ name: "Clothing", value: 20, color: "coral" },
+			{ name: "Home", value: 23, color: "slate" },
+			{ name: "Other", value: 19, color: "amber" },
+		],
+	},
+};

--- a/apps/frontend/components/seller/ui/pages/SalesHeader.tsx
+++ b/apps/frontend/components/seller/ui/pages/SalesHeader.tsx
@@ -43,13 +43,13 @@ export function SalesHeader() {
 				</h1>
 			</div>
 			<div className="flex flex-col sm:flex-row justify-between sm:items-center gap-4">
-				<div className="flex flex-wrap gap-2">
+				<div className="flex flex-wrap gap-2 overflow-x-auto pb-2 -mx-4 sm:mx-0">
 					{tabs.map((tab) => (
 						<Button
 							key={tab.value}
 							variant={activeFilter === tab.value ? "default" : "outline"}
 							onClick={() => setActiveFilter(tab.value)}
-							className={`rounded-full text-sm ${
+							className={`rounded-full text-sm whitespace-nowrap ${
 								activeFilter === tab.value
 									? "bg-black text-white hover:bg-black/90 dark:bg-white dark:text-black dark:hover:bg-white/90"
 									: "dark:border-gray-700 dark:text-gray-300"

--- a/apps/frontend/components/seller/ui/pages/SalesTable.tsx
+++ b/apps/frontend/components/seller/ui/pages/SalesTable.tsx
@@ -72,114 +72,120 @@ export function SalesTable() {
 
 	return (
 		<div className="border rounded-lg bg-white dark:bg-black dark:border-gray-800">
-			<div className="overflow-x-auto">
-				<Table>
-					<TableHeader>
-						<TableRow className="hover:bg-transparent dark:hover:bg-transparent">
-							<TableHead className="w-[50px] dark:text-gray-400" />
-							<TableHead className="font-medium text-sm text-gray-500 dark:text-gray-400">
-								{t("Sales.table.shoppingDate")}
-							</TableHead>
-							<TableHead className="font-medium text-sm text-gray-500 dark:text-gray-400">
-								{t("Sales.table.productName")}
-							</TableHead>
-							<TableHead className="font-medium text-sm text-gray-500 dark:text-gray-400">
-								{t("Sales.table.shoppingId")}
-							</TableHead>
-							<TableHead className="font-medium text-sm text-gray-500 dark:text-gray-400">
-								{t("Sales.table.price")}
-							</TableHead>
-							<TableHead className="font-medium text-sm text-gray-500 dark:text-gray-400">
-								{t("Sales.table.buyer")}
-							</TableHead>
-							<TableHead className="font-medium text-sm text-gray-500 dark:text-gray-400">
-								{t("Sales.table.escrowStatus")}
-							</TableHead>
-						</TableRow>
-					</TableHeader>
-					<TableBody>
-						{sales.map((sale) => (
-							<React.Fragment key={sale.id}>
-								<TableRow className="group dark:hover:bg-black/50">
-									<TableCell className="py-4 align-middle">
-										<Button
-											variant="ghost"
-											size="icon"
-											className="h-8 w-8 dark:hover:bg-black"
-											onClick={() =>
-												setExpandedRow(expandedRow === sale.id ? null : sale.id)
-											}
-										>
-											{expandedRow === sale.id ? (
-												<ChevronDown className="h-4 w-4" />
-											) : (
-												<ChevronRight className="h-4 w-4" />
-											)}
-										</Button>
-									</TableCell>
-									<TableCell className="py-4 align-middle text-sm dark:text-gray-300">
-										{sale.date}
-									</TableCell>
-									<TableCell className="py-4 align-middle font-medium text-sm dark:text-gray-200">
-										{sale.product}
-									</TableCell>
-									<TableCell className="py-4 align-middle text-blue-600 dark:text-blue-400 text-sm">
-										{sale.id}
-									</TableCell>
-									<TableCell className="py-4 align-middle text-sm dark:text-gray-300">
-										${sale.price}
-									</TableCell>
-									<TableCell className="py-4 align-middle text-sm dark:text-gray-300">
-										{sale.buyer}
-									</TableCell>
-									<TableCell className="py-4 align-middle">
-										{getStatusBadge(sale.status)}
-									</TableCell>
-								</TableRow>
-								{expandedRow === sale.id && sale.milestones && (
-									<TableRow className="dark:bg-black/50">
-										<TableCell
-											colSpan={7}
-											className="p-0 border-b dark:border-gray-700"
-										>
-											<div className="py-4 px-14">
-												<h4 className="font-medium mb-4 text-sm dark:text-gray-200">
-													Milestones
-												</h4>
-												<div className="space-y-4">
-													{sale.milestones.map((milestone, index) => (
-														<div
-															key={`${sale.id}-milestone-${index}`}
-															className="grid grid-cols-[100px_1fr_200px] gap-4 items-center"
-														>
-															<div className="text-sm text-gray-500 dark:text-gray-400">
-																{milestone.date}
-															</div>
-															<div className="text-sm font-medium dark:text-gray-300">
-																{t(`Sales.milestones.${milestone.name}`)}
-															</div>
-															<div className="flex items-center justify-end gap-4">
-																{milestone.status === "pending" && (
-																	<Button
-																		className="bg-green-600 hover:bg-green-700 text-xs h-8 text-white dark:bg-green-700 dark:hover:bg-green-600"
-																		size="sm"
-																	>
-																		{t("Sales.milestones.complete")}
-																	</Button>
-																)}
-																{getStatusBadge(milestone.status as StatusType)}
-															</div>
-														</div>
-													))}
-												</div>
-											</div>
+			<div className="overflow-x-auto -mx-4 sm:mx-0">
+				<div className="min-w-[800px]">
+					<Table>
+						<TableHeader>
+							<TableRow className="hover:bg-transparent dark:hover:bg-transparent">
+								<TableHead className="w-[50px] dark:text-gray-400" />
+								<TableHead className="font-medium text-sm text-gray-500 dark:text-gray-400 whitespace-nowrap">
+									{t("Sales.table.shoppingDate")}
+								</TableHead>
+								<TableHead className="font-medium text-sm text-gray-500 dark:text-gray-400 whitespace-nowrap">
+									{t("Sales.table.productName")}
+								</TableHead>
+								<TableHead className="font-medium text-sm text-gray-500 dark:text-gray-400 whitespace-nowrap hidden sm:table-cell">
+									{t("Sales.table.shoppingId")}
+								</TableHead>
+								<TableHead className="font-medium text-sm text-gray-500 dark:text-gray-400 whitespace-nowrap">
+									{t("Sales.table.price")}
+								</TableHead>
+								<TableHead className="font-medium text-sm text-gray-500 dark:text-gray-400 whitespace-nowrap hidden sm:table-cell">
+									{t("Sales.table.buyer")}
+								</TableHead>
+								<TableHead className="font-medium text-sm text-gray-500 dark:text-gray-400 whitespace-nowrap">
+									{t("Sales.table.escrowStatus")}
+								</TableHead>
+							</TableRow>
+						</TableHeader>
+						<TableBody>
+							{sales.map((sale) => (
+								<React.Fragment key={sale.id}>
+									<TableRow className="group dark:hover:bg-black/50">
+										<TableCell className="py-4 align-middle">
+											<Button
+												variant="ghost"
+												size="icon"
+												className="h-8 w-8 dark:hover:bg-black"
+												onClick={() =>
+													setExpandedRow(
+														expandedRow === sale.id ? null : sale.id,
+													)
+												}
+											>
+												{expandedRow === sale.id ? (
+													<ChevronDown className="h-4 w-4" />
+												) : (
+													<ChevronRight className="h-4 w-4" />
+												)}
+											</Button>
+										</TableCell>
+										<TableCell className="py-4 align-middle text-sm dark:text-gray-300">
+											{sale.date}
+										</TableCell>
+										<TableCell className="py-4 align-middle font-medium text-sm dark:text-gray-200">
+											{sale.product}
+										</TableCell>
+										<TableCell className="py-4 align-middle text-blue-600 dark:text-blue-400 text-sm hidden sm:table-cell">
+											{sale.id}
+										</TableCell>
+										<TableCell className="py-4 align-middle text-sm dark:text-gray-300">
+											${sale.price}
+										</TableCell>
+										<TableCell className="py-4 align-middle text-sm dark:text-gray-300 hidden sm:table-cell">
+											{sale.buyer}
+										</TableCell>
+										<TableCell className="py-4 align-middle">
+											{getStatusBadge(sale.status)}
 										</TableCell>
 									</TableRow>
-								)}
-							</React.Fragment>
-						))}
-					</TableBody>
-				</Table>
+									{expandedRow === sale.id && sale.milestones && (
+										<TableRow className="dark:bg-black/50">
+											<TableCell
+												colSpan={7}
+												className="p-0 border-b dark:border-gray-700"
+											>
+												<div className="py-4 px-4 sm:px-14">
+													<h4 className="font-medium mb-4 text-sm dark:text-gray-200">
+														Milestones
+													</h4>
+													<div className="space-y-4">
+														{sale.milestones.map((milestone, index) => (
+															<div
+																key={`${sale.id}-milestone-${index}`}
+																className="grid grid-cols-1 sm:grid-cols-[100px_1fr_200px] gap-2 sm:gap-4 items-start sm:items-center"
+															>
+																<div className="text-sm text-gray-500 dark:text-gray-400">
+																	{milestone.date}
+																</div>
+																<div className="text-sm font-medium dark:text-gray-300">
+																	{t(`Sales.milestones.${milestone.name}`)}
+																</div>
+																<div className="flex items-center justify-start sm:justify-end gap-4">
+																	{milestone.status === "pending" && (
+																		<Button
+																			className="bg-green-600 hover:bg-green-700 text-xs h-8 text-white dark:bg-green-700 dark:hover:bg-green-600"
+																			size="sm"
+																		>
+																			{t("Sales.milestones.complete")}
+																		</Button>
+																	)}
+																	{getStatusBadge(
+																		milestone.status as StatusType,
+																	)}
+																</div>
+															</div>
+														))}
+													</div>
+												</div>
+											</TableCell>
+										</TableRow>
+									)}
+								</React.Fragment>
+							))}
+						</TableBody>
+					</Table>
+				</div>
 			</div>
 			<div className="p-4 border-t dark:border-gray-700">
 				<p className="text-sm text-muted-foreground dark:text-gray-400">

--- a/apps/frontend/components/seller/ui/pages/analytics/CategoryChart.tsx
+++ b/apps/frontend/components/seller/ui/pages/analytics/CategoryChart.tsx
@@ -5,6 +5,7 @@ import {
 	TimeRange,
 } from "@/components/seller/mock/sales-analytics.mock";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { useTranslations } from "next-intl";
 import {
 	Cell,
 	Pie,
@@ -25,19 +26,12 @@ interface LabelProps {
 }
 
 export function CategoryChart({ data, timeRange }: CategoryChartProps) {
+	const t = useTranslations();
 	const getTitle = () => {
-		switch (timeRange) {
-			case "Monthly":
-				return "Categories This Month";
-			case "Quarterly":
-				return "Categories This Quarter";
-			case "Yearly":
-				return "Categories This Year";
-			case "All Time":
-				return "Categories All Time";
-			default:
-				return "Categories";
-		}
+		return (
+			t(`Sales.analytics.categoryChart.title.${timeRange}`) ||
+			t("Sales.analytics.categoryChart.title.default")
+		);
 	};
 
 	return (
@@ -45,7 +39,7 @@ export function CategoryChart({ data, timeRange }: CategoryChartProps) {
 			<CardHeader className="mb-4">
 				<CardTitle className="text-2xl font-semibold">{getTitle()}</CardTitle>
 				<p className="text-sm text-muted-foreground pl-4">
-					Sales breakdown by category
+					{t("Sales.analytics.categoryChart.subtitle")}
 				</p>
 			</CardHeader>
 			<CardContent className="h-[300px]">
@@ -76,7 +70,9 @@ export function CategoryChart({ data, timeRange }: CategoryChartProps) {
 											<div className="grid grid-cols-2 gap-2">
 												<div className="flex flex-col">
 													<span className="text-[0.70rem] uppercase text-muted-foreground">
-														Category
+														{t(
+															"Sales.analytics.categoryChart.tooltip.category",
+														)}
 													</span>
 													<span className="font-bold text-muted-foreground">
 														{data.name}
@@ -84,7 +80,9 @@ export function CategoryChart({ data, timeRange }: CategoryChartProps) {
 												</div>
 												<div className="flex flex-col">
 													<span className="text-[0.70rem] uppercase text-muted-foreground">
-														Percentage
+														{t(
+															"Sales.analytics.categoryChart.tooltip.percentage",
+														)}
 													</span>
 													<span className="font-bold">{data.value}%</span>
 												</div>

--- a/apps/frontend/components/seller/ui/pages/analytics/CategoryChart.tsx
+++ b/apps/frontend/components/seller/ui/pages/analytics/CategoryChart.tsx
@@ -1,0 +1,103 @@
+"use client";
+
+import {
+	CategorySales,
+	TimeRange,
+} from "@/components/seller/mock/sales-analytics.mock";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+	Cell,
+	Pie,
+	PieChart,
+	TooltipProps as RechartsTooltipProps,
+	ResponsiveContainer,
+	Tooltip,
+} from "recharts";
+
+interface CategoryChartProps {
+	data: CategorySales[];
+	timeRange: TimeRange;
+}
+
+interface LabelProps {
+	name: string;
+	value: number;
+}
+
+export function CategoryChart({ data, timeRange }: CategoryChartProps) {
+	const getTitle = () => {
+		switch (timeRange) {
+			case "Monthly":
+				return "Categories This Month";
+			case "Quarterly":
+				return "Categories This Quarter";
+			case "Yearly":
+				return "Categories This Year";
+			case "All Time":
+				return "Categories All Time";
+			default:
+				return "Categories";
+		}
+	};
+
+	return (
+		<Card className="col-span-2 mt-4 md:mt-0">
+			<CardHeader className="mb-4">
+				<CardTitle className="text-2xl font-semibold">{getTitle()}</CardTitle>
+				<p className="text-sm text-muted-foreground pl-4">
+					Sales breakdown by category
+				</p>
+			</CardHeader>
+			<CardContent className="h-[300px]">
+				<ResponsiveContainer width="100%" height="100%">
+					<PieChart>
+						<Pie
+							data={data}
+							dataKey="value"
+							nameKey="name"
+							cx="50%"
+							cy="50%"
+							outerRadius={80}
+							label={({ name, value }: LabelProps) => `${name}: ${value}%`}
+						>
+							{data.map((entry) => (
+								<Cell key={entry.name} fill={entry.color} />
+							))}
+						</Pie>
+						<Tooltip
+							content={({
+								active,
+								payload,
+							}: RechartsTooltipProps<number, string>) => {
+								if (active && payload && payload.length) {
+									const data = payload[0].payload as CategorySales;
+									return (
+										<div className="rounded-lg border bg-background p-2 shadow-sm">
+											<div className="grid grid-cols-2 gap-2">
+												<div className="flex flex-col">
+													<span className="text-[0.70rem] uppercase text-muted-foreground">
+														Category
+													</span>
+													<span className="font-bold text-muted-foreground">
+														{data.name}
+													</span>
+												</div>
+												<div className="flex flex-col">
+													<span className="text-[0.70rem] uppercase text-muted-foreground">
+														Percentage
+													</span>
+													<span className="font-bold">{data.value}%</span>
+												</div>
+											</div>
+										</div>
+									);
+								}
+								return null;
+							}}
+						/>
+					</PieChart>
+				</ResponsiveContainer>
+			</CardContent>
+		</Card>
+	);
+}

--- a/apps/frontend/components/seller/ui/pages/analytics/SalesAnalytics.tsx
+++ b/apps/frontend/components/seller/ui/pages/analytics/SalesAnalytics.tsx
@@ -21,7 +21,7 @@ export function SalesAnalytics() {
 
 	return (
 		<Tabs defaultValue="Monthly" className="space-y-4">
-			<TabsList className="w-full overflow-x-auto flex-nowrap">
+			<TabsList className="overflow-x-auto flex-nowrap">
 				{timeRanges.map((range) => (
 					<TabsTrigger key={range} value={range} className="whitespace-nowrap">
 						{t(`Sales.analytics.timeRanges.${range}`)}

--- a/apps/frontend/components/seller/ui/pages/analytics/SalesAnalytics.tsx
+++ b/apps/frontend/components/seller/ui/pages/analytics/SalesAnalytics.tsx
@@ -5,11 +5,13 @@ import {
 	mockSalesData,
 } from "@/components/seller/mock/sales-analytics.mock";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { useTranslations } from "next-intl";
 import { CategoryChart } from "./CategoryChart";
 import { SalesChart } from "./SalesChart";
 import { StatsCards } from "./StatsCards";
 
 export function SalesAnalytics() {
+	const t = useTranslations();
 	const timeRanges: TimeRange[] = [
 		"Monthly",
 		"Quarterly",
@@ -22,7 +24,7 @@ export function SalesAnalytics() {
 			<TabsList>
 				{timeRanges.map((range) => (
 					<TabsTrigger key={range} value={range}>
-						{range}
+						{t(`Sales.analytics.timeRanges.${range}`)}
 					</TabsTrigger>
 				))}
 			</TabsList>

--- a/apps/frontend/components/seller/ui/pages/analytics/SalesAnalytics.tsx
+++ b/apps/frontend/components/seller/ui/pages/analytics/SalesAnalytics.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import {
+	TimeRange,
+	mockSalesData,
+} from "@/components/seller/mock/sales-analytics.mock";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { CategoryChart } from "./CategoryChart";
+import { SalesChart } from "./SalesChart";
+import { StatsCards } from "./StatsCards";
+
+export function SalesAnalytics() {
+	const timeRanges: TimeRange[] = [
+		"Monthly",
+		"Quarterly",
+		"Yearly",
+		"All Time",
+	];
+
+	return (
+		<Tabs defaultValue="Monthly" className="space-y-4">
+			<TabsList>
+				{timeRanges.map((range) => (
+					<TabsTrigger key={range} value={range}>
+						{range}
+					</TabsTrigger>
+				))}
+			</TabsList>
+			{timeRanges.map((range) => (
+				<TabsContent key={range} value={range} className="space-y-4">
+					<div className="grid gap-4 grid-cols-1 sm:grid-cols-2 lg:grid-cols-6">
+						<StatsCards data={mockSalesData[range]} />
+					</div>
+					<div className="grid grid-cols-1 md:grid-cols-10 md:gap-4">
+						<div className="md:col-span-5">
+							<SalesChart
+								data={mockSalesData[range].salesByDay}
+								timeRange={range}
+							/>
+						</div>
+						<div className="md:col-span-5">
+							<CategoryChart
+								data={mockSalesData[range].categorySales}
+								timeRange={range}
+							/>
+						</div>
+					</div>
+				</TabsContent>
+			))}
+		</Tabs>
+	);
+}

--- a/apps/frontend/components/seller/ui/pages/analytics/SalesAnalytics.tsx
+++ b/apps/frontend/components/seller/ui/pages/analytics/SalesAnalytics.tsx
@@ -21,9 +21,9 @@ export function SalesAnalytics() {
 
 	return (
 		<Tabs defaultValue="Monthly" className="space-y-4">
-			<TabsList>
+			<TabsList className="w-full overflow-x-auto flex-nowrap">
 				{timeRanges.map((range) => (
-					<TabsTrigger key={range} value={range}>
+					<TabsTrigger key={range} value={range} className="whitespace-nowrap">
 						{t(`Sales.analytics.timeRanges.${range}`)}
 					</TabsTrigger>
 				))}
@@ -33,14 +33,14 @@ export function SalesAnalytics() {
 					<div className="grid gap-4 grid-cols-1 sm:grid-cols-2 lg:grid-cols-6">
 						<StatsCards data={mockSalesData[range]} />
 					</div>
-					<div className="grid grid-cols-1 md:grid-cols-10 md:gap-4">
-						<div className="md:col-span-5">
+					<div className="grid grid-cols-1 gap-4">
+						<div className="w-full">
 							<SalesChart
 								data={mockSalesData[range].salesByDay}
 								timeRange={range}
 							/>
 						</div>
-						<div className="md:col-span-5">
+						<div className="w-full">
 							<CategoryChart
 								data={mockSalesData[range].categorySales}
 								timeRange={range}

--- a/apps/frontend/components/seller/ui/pages/analytics/SalesAnalyticsHeader.tsx
+++ b/apps/frontend/components/seller/ui/pages/analytics/SalesAnalyticsHeader.tsx
@@ -1,0 +1,10 @@
+import { BarChart } from "lucide-react";
+
+export function SalesAnalyticsHeader() {
+	return (
+		<div className="flex items-center gap-2 sm:mb-0">
+			<BarChart className="h-5 w-5" />
+			<h1 className="text-lg font-semibold">Sales Overview</h1>
+		</div>
+	);
+}

--- a/apps/frontend/components/seller/ui/pages/analytics/SalesAnalyticsHeader.tsx
+++ b/apps/frontend/components/seller/ui/pages/analytics/SalesAnalyticsHeader.tsx
@@ -1,10 +1,12 @@
 import { BarChart } from "lucide-react";
+import { useTranslations } from "next-intl";
 
 export function SalesAnalyticsHeader() {
+	const t = useTranslations();
 	return (
 		<div className="flex items-center gap-2 sm:mb-0">
 			<BarChart className="h-5 w-5" />
-			<h1 className="text-lg font-semibold">Sales Overview</h1>
+			<h1 className="text-lg font-semibold">{t("Sales.analytics.overview")}</h1>
 		</div>
 	);
 }

--- a/apps/frontend/components/seller/ui/pages/analytics/SalesChart.tsx
+++ b/apps/frontend/components/seller/ui/pages/analytics/SalesChart.tsx
@@ -5,6 +5,7 @@ import {
 	TimeRange,
 } from "@/components/seller/mock/sales-analytics.mock";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { useTranslations } from "next-intl";
 import {
 	Line,
 	LineChart,
@@ -21,19 +22,12 @@ interface SalesChartProps {
 }
 
 export function SalesChart({ data, timeRange }: SalesChartProps) {
+	const t = useTranslations();
 	const getTitle = () => {
-		switch (timeRange) {
-			case "Monthly":
-				return "Sales This Month";
-			case "Quarterly":
-				return "Sales This Quarter";
-			case "Yearly":
-				return "Sales This Year";
-			case "All Time":
-				return "Sales All Time";
-			default:
-				return "Sales";
-		}
+		return (
+			t(`Sales.analytics.salesChart.title.${timeRange}`) ||
+			t("Sales.analytics.salesChart.title.default")
+		);
 	};
 
 	return (
@@ -41,7 +35,7 @@ export function SalesChart({ data, timeRange }: SalesChartProps) {
 			<CardHeader className="mb-4">
 				<CardTitle className="text-2xl font-semibold">{getTitle()}</CardTitle>
 				<p className="text-sm text-muted-foreground pl-4">
-					Number of sales over time
+					{t("Sales.analytics.salesChart.subtitle")}
 				</p>
 			</CardHeader>
 			<CardContent className="h-[300px]">
@@ -72,7 +66,7 @@ export function SalesChart({ data, timeRange }: SalesChartProps) {
 											<div className="grid grid-cols-2 gap-2">
 												<div className="flex flex-col">
 													<span className="text-[0.70rem] uppercase text-muted-foreground">
-														Date
+														{t("Sales.analytics.salesChart.tooltip.date")}
 													</span>
 													<span className="font-bold text-muted-foreground">
 														{new Date(data.date).toLocaleDateString()}
@@ -80,7 +74,7 @@ export function SalesChart({ data, timeRange }: SalesChartProps) {
 												</div>
 												<div className="flex flex-col">
 													<span className="text-[0.70rem] uppercase text-muted-foreground">
-														Sales
+														{t("Sales.analytics.salesChart.tooltip.sales")}
 													</span>
 													<span className="font-bold">${data.sales}</span>
 												</div>

--- a/apps/frontend/components/seller/ui/pages/analytics/SalesChart.tsx
+++ b/apps/frontend/components/seller/ui/pages/analytics/SalesChart.tsx
@@ -1,0 +1,111 @@
+"use client";
+
+import {
+	SalesByDay,
+	TimeRange,
+} from "@/components/seller/mock/sales-analytics.mock";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+	Line,
+	LineChart,
+	TooltipProps as RechartsTooltipProps,
+	ResponsiveContainer,
+	Tooltip,
+	XAxis,
+	YAxis,
+} from "recharts";
+
+interface SalesChartProps {
+	data: SalesByDay[];
+	timeRange: TimeRange;
+}
+
+export function SalesChart({ data, timeRange }: SalesChartProps) {
+	const getTitle = () => {
+		switch (timeRange) {
+			case "Monthly":
+				return "Sales This Month";
+			case "Quarterly":
+				return "Sales This Quarter";
+			case "Yearly":
+				return "Sales This Year";
+			case "All Time":
+				return "Sales All Time";
+			default:
+				return "Sales";
+		}
+	};
+
+	return (
+		<Card className="col-span-4">
+			<CardHeader className="mb-4">
+				<CardTitle className="text-2xl font-semibold">{getTitle()}</CardTitle>
+				<p className="text-sm text-muted-foreground pl-4">
+					Number of sales over time
+				</p>
+			</CardHeader>
+			<CardContent className="h-[300px]">
+				<ResponsiveContainer width="100%" height="100%">
+					<LineChart data={data}>
+						<XAxis
+							dataKey="date"
+							tickFormatter={(value: string) =>
+								new Date(value).getDate().toString()
+							}
+							stroke="#888888"
+							fontSize={12}
+						/>
+						<YAxis
+							stroke="#888888"
+							fontSize={12}
+							tickFormatter={(value: number) => `$${value}`}
+						/>
+						<Tooltip
+							content={({
+								active,
+								payload,
+							}: RechartsTooltipProps<number, string>) => {
+								if (active && payload && payload.length) {
+									const data = payload[0].payload as SalesByDay;
+									return (
+										<div className="rounded-lg border bg-background p-2 shadow-sm">
+											<div className="grid grid-cols-2 gap-2">
+												<div className="flex flex-col">
+													<span className="text-[0.70rem] uppercase text-muted-foreground">
+														Date
+													</span>
+													<span className="font-bold text-muted-foreground">
+														{new Date(data.date).toLocaleDateString()}
+													</span>
+												</div>
+												<div className="flex flex-col">
+													<span className="text-[0.70rem] uppercase text-muted-foreground">
+														Sales
+													</span>
+													<span className="font-bold">${data.sales}</span>
+												</div>
+											</div>
+										</div>
+									);
+								}
+								return null;
+							}}
+						/>
+						<Line
+							type="monotone"
+							dataKey="sales"
+							strokeWidth={2}
+							activeDot={{
+								r: 4,
+								style: { fill: "hsl(var(--primary))" },
+							}}
+							style={{
+								stroke: "hsl(var(--primary))",
+							}}
+						/>
+					</LineChart>
+				</ResponsiveContainer>
+			</CardContent>
+		</Card>
+	);
+}

--- a/apps/frontend/components/seller/ui/pages/analytics/SalesTabContent.tsx
+++ b/apps/frontend/components/seller/ui/pages/analytics/SalesTabContent.tsx
@@ -1,14 +1,16 @@
-import { TimeRange } from "@/components/seller/mock/sales-analytics.mock";
+import {
+	CategorySales,
+	SalesAnalytics,
+	SalesByDay,
+	TimeRange,
+} from "@/components/seller/mock/sales-analytics.mock";
 import { CategoryChart } from "./CategoryChart";
 import { SalesChart } from "./SalesChart";
 import { StatsCards } from "./StatsCards";
 
 interface SalesTabContentProps {
 	range: TimeRange;
-	data: {
-		salesByDay: any[];
-		categorySales: any[];
-	};
+	data: SalesAnalytics;
 }
 
 export function SalesTabContent({ range, data }: SalesTabContentProps) {
@@ -18,8 +20,8 @@ export function SalesTabContent({ range, data }: SalesTabContentProps) {
 				<StatsCards data={data} />
 			</div>
 			<div className="grid gap-4 grid-cols-1 md:grid-cols-2">
-				<SalesChart data={data.salesByDay} />
-				<CategoryChart data={data.categorySales} />
+				<SalesChart data={data.salesByDay} timeRange={range} />
+				<CategoryChart data={data.categorySales} timeRange={range} />
 			</div>
 		</div>
 	);

--- a/apps/frontend/components/seller/ui/pages/analytics/SalesTabContent.tsx
+++ b/apps/frontend/components/seller/ui/pages/analytics/SalesTabContent.tsx
@@ -1,0 +1,26 @@
+import { TimeRange } from "@/components/seller/mock/sales-analytics.mock";
+import { CategoryChart } from "./CategoryChart";
+import { SalesChart } from "./SalesChart";
+import { StatsCards } from "./StatsCards";
+
+interface SalesTabContentProps {
+	range: TimeRange;
+	data: {
+		salesByDay: any[];
+		categorySales: any[];
+	};
+}
+
+export function SalesTabContent({ range, data }: SalesTabContentProps) {
+	return (
+		<div className="space-y-4">
+			<div className="grid gap-4 grid-cols-1 sm:grid-cols-2 lg:grid-cols-6">
+				<StatsCards data={data} />
+			</div>
+			<div className="grid gap-4 grid-cols-1 md:grid-cols-2">
+				<SalesChart data={data.salesByDay} />
+				<CategoryChart data={data.categorySales} />
+			</div>
+		</div>
+	);
+}

--- a/apps/frontend/components/seller/ui/pages/analytics/StatsCards.tsx
+++ b/apps/frontend/components/seller/ui/pages/analytics/StatsCards.tsx
@@ -1,6 +1,7 @@
 import { SalesAnalytics } from "@/components/seller/mock/sales-analytics.mock";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { DollarSign, Package, TrendingUp } from "lucide-react";
+import { useTranslations } from "next-intl";
 
 interface StatsCardsProps {
 	data: Pick<
@@ -10,6 +11,7 @@ interface StatsCardsProps {
 }
 
 export function StatsCards({ data }: StatsCardsProps) {
+	const t = useTranslations();
 	const currencyFormatter = new Intl.NumberFormat("en-US", {
 		style: "currency",
 		currency: "USD",
@@ -24,17 +26,17 @@ export function StatsCards({ data }: StatsCardsProps) {
 
 	const stats = [
 		{
-			title: "Total Sales",
+			title: t("Sales.analytics.stats.totalSales"),
 			value: currencyFormatter.format(data.totalSales),
 			icon: DollarSign,
 		},
 		{
-			title: "Average Order",
+			title: t("Sales.analytics.stats.averageOrder"),
 			value: currencyFormatter.format(data.averageOrderValue),
 			icon: TrendingUp,
 		},
 		{
-			title: "Total Orders",
+			title: t("Sales.analytics.stats.totalOrders"),
 			value: numberFormatter.format(data.totalOrders),
 			icon: Package,
 		},

--- a/apps/frontend/components/seller/ui/pages/analytics/StatsCards.tsx
+++ b/apps/frontend/components/seller/ui/pages/analytics/StatsCards.tsx
@@ -1,0 +1,58 @@
+import { SalesAnalytics } from "@/components/seller/mock/sales-analytics.mock";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { DollarSign, Package, TrendingUp } from "lucide-react";
+
+interface StatsCardsProps {
+	data: Pick<
+		SalesAnalytics,
+		"totalSales" | "averageOrderValue" | "totalOrders"
+	>;
+}
+
+export function StatsCards({ data }: StatsCardsProps) {
+	const currencyFormatter = new Intl.NumberFormat("en-US", {
+		style: "currency",
+		currency: "USD",
+		minimumFractionDigits: 0,
+		maximumFractionDigits: 0,
+	});
+
+	const numberFormatter = new Intl.NumberFormat("en-US", {
+		minimumFractionDigits: 0,
+		maximumFractionDigits: 0,
+	});
+
+	const stats = [
+		{
+			title: "Total Sales",
+			value: currencyFormatter.format(data.totalSales),
+			icon: DollarSign,
+		},
+		{
+			title: "Average Order",
+			value: currencyFormatter.format(data.averageOrderValue),
+			icon: TrendingUp,
+		},
+		{
+			title: "Total Orders",
+			value: numberFormatter.format(data.totalOrders),
+			icon: Package,
+		},
+	];
+
+	return (
+		<>
+			{stats.map((stat) => (
+				<Card key={stat.title} className="col-span-2">
+					<CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+						<CardTitle className="text-sm font-medium">{stat.title}</CardTitle>
+						<stat.icon className="h-4 w-4 text-muted-foreground m-3" />
+					</CardHeader>
+					<CardContent>
+						<div className="text-2xl font-bold">{stat.value}</div>
+					</CardContent>
+				</Card>
+			))}
+		</>
+	);
+}

--- a/apps/frontend/components/ui/tabs.tsx
+++ b/apps/frontend/components/ui/tabs.tsx
@@ -1,0 +1,52 @@
+import { cn } from "@/lib/utils";
+import * as TabsPrimitive from "@radix-ui/react-tabs";
+import * as React from "react";
+
+const Tabs = TabsPrimitive.Root;
+
+const TabsList = React.forwardRef<
+	React.ElementRef<typeof TabsPrimitive.List>,
+	React.ComponentPropsWithoutRef<typeof TabsPrimitive.List>
+>(({ className, ...props }, ref) => (
+	<TabsPrimitive.List
+		ref={ref}
+		className={cn(
+			"inline-flex h-10 items-center justify-center rounded-md bg-muted p-1 text-muted-foreground",
+			className,
+		)}
+		{...props}
+	/>
+));
+TabsList.displayName = TabsPrimitive.List.displayName;
+
+const TabsTrigger = React.forwardRef<
+	React.ElementRef<typeof TabsPrimitive.Trigger>,
+	React.ComponentPropsWithoutRef<typeof TabsPrimitive.Trigger>
+>(({ className, ...props }, ref) => (
+	<TabsPrimitive.Trigger
+		ref={ref}
+		className={cn(
+			"inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow-sm",
+			className,
+		)}
+		{...props}
+	/>
+));
+TabsTrigger.displayName = TabsPrimitive.Trigger.displayName;
+
+const TabsContent = React.forwardRef<
+	React.ElementRef<typeof TabsPrimitive.Content>,
+	React.ComponentPropsWithoutRef<typeof TabsPrimitive.Content>
+>(({ className, ...props }, ref) => (
+	<TabsPrimitive.Content
+		ref={ref}
+		className={cn(
+			"mt-2 ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+			className,
+		)}
+		{...props}
+	/>
+));
+TabsContent.displayName = TabsPrimitive.Content.displayName;
+
+export { Tabs, TabsList, TabsTrigger, TabsContent };

--- a/apps/frontend/locales/en.ts
+++ b/apps/frontend/locales/en.ts
@@ -517,46 +517,47 @@ export const en = {
 			deliveryExpected: "Delivery Expected",
 		},
 		total: "Total Shopping",
-		Sales: {
-			title: "My Sales",
-			searchPlaceholder: "Search sales...",
-			filters: {
-				all: "All",
-				pending: "Pending",
-				onDispute: "On Dispute",
-				forReview: "For Review",
-				approved: "Approved",
+		analytics: {
+			overview: "Sales Overview",
+			timeRanges: {
+				Monthly: "Monthly",
+				Quarterly: "Quarterly",
+				Yearly: "Yearly",
+				"All Time": "All Time",
 			},
-			table: {
-				shoppingDate: "Shopping Date",
-				productName: "Product Name",
-				shoppingId: "Shopping ID",
-				price: "Price",
-				buyer: "Buyer",
-				escrowStatus: "Escrow Status",
+			stats: {
+				totalSales: "Total Sales",
+				averageOrder: "Average Order",
+				totalOrders: "Total Orders",
 			},
-			status: {
-				approved: "Approved",
-				pending: "Pending",
-				onDispute: "On Dispute",
-				forReview: "For Review",
-			},
-			milestones: {
-				title: "Milestones",
-				date: "Date",
-				name: "Name",
-				status: "Status",
-				actions: "Actions",
-				complete: "Complete",
-
-				items: {
-					orderPlaced: "Order Placed",
-					paymentConfirmed: "Payment Confirmed",
-					productShipped: "Product Shipped",
-					deliveryExpected: "Delivery Expected",
+			salesChart: {
+				title: {
+					Monthly: "Sales This Month",
+					Quarterly: "Sales This Quarter",
+					Yearly: "Sales This Year",
+					"All Time": "Sales All Time",
+					default: "Sales",
+				},
+				subtitle: "Number of sales over time",
+				tooltip: {
+					date: "Date",
+					sales: "Sales",
 				},
 			},
-			total: "Total Shopping",
+			categoryChart: {
+				title: {
+					Monthly: "Categories This Month",
+					Quarterly: "Categories This Quarter",
+					Yearly: "Categories This Year",
+					"All Time": "Categories All Time",
+					default: "Categories",
+				},
+				subtitle: "Sales breakdown by category",
+				tooltip: {
+					category: "Category",
+					percentage: "Percentage",
+				},
+			},
 		},
 	},
 
@@ -610,7 +611,7 @@ export const en = {
 	},
 	notFound: {
 		title: "Page Not Found",
-		message: "The page you are looking for doesn’t exist or has been moved.",
+		message: "The page you are looking for doesn't exist or has been moved.",
 		browser: "Browse Marketplace",
 		return: "Go Home",
 	},

--- a/apps/frontend/locales/es.ts
+++ b/apps/frontend/locales/es.ts
@@ -491,7 +491,7 @@ export const es = {
 			all: "Todas",
 			pending: "Pendientes",
 			onDispute: "En Disputa",
-			forReview: "En Revisión",
+			forReview: "Para Revisar",
 			approved: "Aprobadas",
 		},
 		table: {
@@ -503,10 +503,10 @@ export const es = {
 			escrowStatus: "Estado de Custodia",
 		},
 		status: {
-			approved: "Aprobado",
+			approved: "Aprobada",
 			pending: "Pendiente",
+			forReview: "Para Revisar",
 			onDispute: "En Disputa",
-			forReview: "En Revisión",
 		},
 		milestones: {
 			title: "Hitos",
@@ -515,12 +515,54 @@ export const es = {
 			status: "Estado",
 			actions: "Acciones",
 			complete: "Completar",
-			orderPlaced: "Pedido realizado",
-			paymentConfirmed: "Pago confirmado",
-			productShipped: "Producto enviado",
-			deliveryExpected: "Entrega esperada",
+			orderPlaced: "Pedido Realizado",
+			paymentConfirmed: "Pago Confirmado",
+			productShipped: "Producto Enviado",
+			deliveryExpected: "Entrega Esperada",
 		},
-		total: "Total de Compras",
+		total: "Ventas Totales",
+		analytics: {
+			overview: "Resumen de Ventas",
+			timeRanges: {
+				Monthly: "Mensual",
+				Quarterly: "Trimestral",
+				Yearly: "Anual",
+				"All Time": "Todo el Período",
+			},
+			stats: {
+				totalSales: "Ventas Totales",
+				averageOrder: "Pedido Promedio",
+				totalOrders: "Pedidos Totales",
+			},
+			salesChart: {
+				title: {
+					Monthly: "Ventas de este Mes",
+					Quarterly: "Ventas de este Trimestre",
+					Yearly: "Ventas de este Año",
+					"All Time": "Ventas Totales",
+					default: "Ventas",
+				},
+				subtitle: "Número de ventas en el tiempo",
+				tooltip: {
+					date: "Fecha",
+					sales: "Ventas",
+				},
+			},
+			categoryChart: {
+				title: {
+					Monthly: "Categorías de este Mes",
+					Quarterly: "Categorías de este Trimestre",
+					Yearly: "Categorías de este Año",
+					"All Time": "Categorías Totales",
+					default: "Categorías",
+				},
+				subtitle: "Desglose de ventas por categoría",
+				tooltip: {
+					category: "Categoría",
+					percentage: "Porcentaje",
+				},
+			},
+		},
 	},
 
 	filters: {

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -22,6 +22,7 @@
 		"@radix-ui/react-separator": "^1.1.2",
 		"@radix-ui/react-slot": "^1.1.2",
 		"@radix-ui/react-switch": "^1.1.2",
+		"@radix-ui/react-tabs": "^1.1.3",
 		"@radix-ui/react-toast": "^1.2.6",
 		"@radix-ui/react-tooltip": "^1.1.8",
 		"@radix-ui/themes": "^3.1.4",
@@ -38,6 +39,7 @@
 		"react": "^18",
 		"react-dom": "^18",
 		"react-hook-form": "^7.54.2",
+		"recharts": "^2.15.1",
 		"shadcn-ui": "^0.9.4",
 		"sharp": "^0.33.5",
 		"tailwind-merge": "^2.6.0",
@@ -48,6 +50,7 @@
 		"@types/node": "^20",
 		"@types/react": "^18",
 		"@types/react-dom": "^18",
+		"@types/recharts": "^1.8.29",
 		"postcss": "^8",
 		"tailwindcss": "^3.4.1",
 		"typescript": "^5"


### PR DESCRIPTION
# 📝 Pull Request Title
Add Sales Analytics Dashboard for Sellers

## 🛠️ Issue
- Closes #216 

## 📖 Description
Implements a comprehensive sales analytics dashboard for sellers to monitor their business performance through various time ranges and metrics. The dashboard includes interactive charts, key performance indicators, and filterable time periods.

## ✅ Changes made
- Added new analytics components:
  - `SalesAnalytics`: Main component with time-range tabs
  - `SalesAnalyticsHeader`: Header component with analytics title
  - `SalesChart`: Interactive line chart for sales trends
  - `CategoryChart`: Pie chart for category distribution
  - `StatsCards`: KPI cards showing key metrics
- Implemented mock data structure for analytics visualization
- Added new dependencies:
  - `recharts` for data visualization
  - `@radix-ui/react-tabs` for tab navigation
- Integrated analytics section into the seller sales page
- Added responsive layout with grid system for different screen sizes

## 🖼️ Media (screenshots/videos)
- [Please add screenshots of the following views:
  - Full analytics dashboard

https://github.com/user-attachments/assets/4e900108-f013-4d94-a2d5-b9b493130529


  - Mobile responsive layout]
  
![mobile](https://github.com/user-attachments/assets/0d7d9a0c-6141-4a8a-bf80-1daf1f45e15e)


## 📜 Additional Notes
- The dashboard currently uses mock data for demonstration
- Supports 4 time ranges: Monthly, Quarterly, Yearly, and All Time
- All components are fully responsive and follow the design system
- Uses shadcn/ui components for consistent styling