### PR TITLE
feat: make pagination functional

### DIFF
--- a/apps/frontend/components/marketplace/products-pagination.tsx
+++ b/apps/frontend/components/marketplace/products-pagination.tsx
@@ -17,25 +17,52 @@ import {
 } from "@/components/ui/select";
 import { useTranslations } from "next-intl";
 
-export const ProductsPagination = () => {
+type Props = {
+	currentPage: number;
+	totalPages: number;
+	setCurrentPage: (page: number) => void;
+	pageSize: number;
+	setPageSize: (size: number) => void;
+};
+
+export const ProductsPagination = ({
+	currentPage,
+	totalPages,
+	setCurrentPage,
+	pageSize,
+	setPageSize,
+}: Props) => {
+
 	const t = useTranslations();
+
+	const handlePageSizeChange = (value: string) => {
+		setPageSize(Number(value));
+	};
+
+	const handlePrevious = () => {
+		if (currentPage > 1) setCurrentPage(currentPage - 1);
+	};
+
+	const handleNext = () => {
+		if (currentPage < totalPages) setCurrentPage(currentPage + 1);
+	};
 	return (
 		<section className="w-full pt-5 mt-2 flex flex-col gap-5 lg:flex-row lg:gap-0">
 			<div className="w-full gap-2 flex items-center justify-center lg:justify-start lg:w-[50%]">
 				<label className="opacity-80" htmlFor="show-results">
 					{t("pagination.showResult")}:
 				</label>
-				<Select>
+				<Select onValueChange={handlePageSizeChange} value={pageSize.toString()}>
 					<SelectTrigger id="show-results" className="w-[70px]">
-						<SelectValue placeholder="10" />
+						<SelectValue placeholder={pageSize.toString()} />
 					</SelectTrigger>
 					<SelectContent className="min-w-[70px]">
 						<SelectGroup>
-							<SelectItem value="10">10</SelectItem>
-							<SelectItem value="20">20</SelectItem>
-							<SelectItem value="30">30</SelectItem>
-							<SelectItem value="40">40</SelectItem>
-							<SelectItem value="50">50</SelectItem>
+							{["10", "20", "30", "40", "50"].map((val) => (
+								<SelectItem key={val} value={val}>
+									{val}
+								</SelectItem>
+							))}
 						</SelectGroup>
 					</SelectContent>
 				</Select>
@@ -45,25 +72,38 @@ export const ProductsPagination = () => {
 				<Pagination className="justify-center lg:justify-end">
 					<PaginationContent>
 						<PaginationItem>
-							<PaginationPrevious href="#" />
+							<PaginationPrevious
+								href="#"
+								onClick={(e) => {
+									e.preventDefault();
+									handlePrevious();
+								}}
+							/>
 						</PaginationItem>
+
+						{Array.from({ length: totalPages }, (_, i) => (
+							<PaginationItem key={i}>
+								<PaginationLink
+									href="#"
+									isActive={currentPage === i + 1}
+									onClick={(e) => {
+										e.preventDefault();
+										setCurrentPage(i + 1);
+									}}
+								>
+									{i + 1}
+								</PaginationLink>
+							</PaginationItem>
+						))}
+
 						<PaginationItem>
-							<PaginationLink href="#">1</PaginationLink>
-						</PaginationItem>
-						<PaginationItem>
-							<PaginationLink href="#">2</PaginationLink>
-						</PaginationItem>
-						<PaginationItem>
-							<PaginationLink href="#">3</PaginationLink>
-						</PaginationItem>
-						<PaginationItem>
-							<PaginationLink href="#">4</PaginationLink>
-						</PaginationItem>
-						<PaginationItem>
-							<PaginationEllipsis />
-						</PaginationItem>
-						<PaginationItem>
-							<PaginationNext href="#" />
+							<PaginationNext
+								href="#"
+								onClick={(e) => {
+									e.preventDefault();
+									handleNext();
+								}}
+							/>
 						</PaginationItem>
 					</PaginationContent>
 				</Pagination>

--- a/apps/frontend/components/products/product-list.tsx
+++ b/apps/frontend/components/products/product-list.tsx
@@ -78,6 +78,15 @@ export default function ProductList() {
 		fetchData();
 	}, []);
 
+	// State for pagination
+	const [currentPage, setCurrentPage] = useState(1);
+	const [pageSize, setPageSize] = useState(10);
+
+	// Reset to page 1 when filters or pageSize changes
+	useEffect(() => {
+		setCurrentPage(1);
+	}, [filters, pageSize]);
+
 	const filteredProducts = useFilteredProducts(
 		productsData,
 		categoriesData,
@@ -85,6 +94,11 @@ export default function ProductList() {
 		filters,
 		loading,
 	);
+
+	const startIndex = (currentPage - 1) * pageSize;
+	const endIndex = startIndex + pageSize;
+	const paginatedProducts = filteredProducts.slice(startIndex, endIndex);
+	const totalPages = Math.ceil(filteredProducts.length / pageSize);
 
 	const handleClearFilters = () => {
 		setFilters(initialFilters);
@@ -110,12 +124,19 @@ export default function ProductList() {
 					<ProductsNotFound onClear={handleClearFilters} />
 				) : (
 					<div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
-						{filteredProducts.map((product) => (
+						{paginatedProducts.map((product) => (
 							<ProductCard key={product.id} product={product} t={t} />
 						))}
 					</div>
 				)}
-				<ProductsPagination />
+				<ProductsPagination
+					currentPage={currentPage}
+					totalPages={totalPages}
+					setCurrentPage={setCurrentPage}
+					pageSize={pageSize}
+					setPageSize={setPageSize}
+				/>
+
 			</section>
 		</>
 	);


### PR DESCRIPTION
# 📝 Pull Request Title
Implement Client-Side Pagination for Marketplace Page

## 🛠️ Issue
- Closes #230 

## 📖 Description
- This PR adds client-side pagination functionality to the /marketplace page. Since the backend does not currently support pagination, this feature improves user experience by limiting the number of displayed products using JavaScript array slicing.

## ✅ Changes made
- Added currentPage and pageSize state to product-list.tsx
- Implemented logic to slice the filtered product list based on the current page and selected page size
- Updated the ProductsPagination component to:
- Navigate between pages using "Previous", "Next", and page number links
- Select the number of results per page (10, 20, 30, 40, 50)
- Reset to page 1 when filters or page size change

## 🖼️ Media (screenshots/videos)
[SAFESWAP.webm](https://github.com/user-attachments/assets/eb21db1a-3c13-4155-abbb-a59af1c89145)


## 📜 Additional Notes
- 
