### PR TITLE
feat: add TabBar component

### DIFF
--- a/p2p-safe-swap/frontend/components/ui/tab-bar.tsx
+++ b/p2p-safe-swap/frontend/components/ui/tab-bar.tsx
@@ -20,6 +20,7 @@ export function TabBar({
   const tabRefs = React.useRef<(HTMLButtonElement | null)[]>([]);
 
   const handleKeyDown = (e: React.KeyboardEvent, index: number) => {
+    if (tabs.length === 0) return;
     let next = index;
     if (e.key === "ArrowRight") next = (index + 1) % tabs.length;
     else if (e.key === "ArrowLeft") next = (index - 1 + tabs.length) % tabs.length;
@@ -30,6 +31,8 @@ export function TabBar({
     onChange(next);
     tabRefs.current[next]?.focus();
   };
+
+  if (tabs.length === 0) return null;
 
   return (
     <div
@@ -46,7 +49,7 @@ export function TabBar({
         const isActive = index === activeIndex;
         return (
           <button
-            key={index}
+            key={`${label}-${index}`}
             ref={(el) => {
               tabRefs.current[index] = el;
             }}

--- a/p2p-safe-swap/frontend/components/ui/tab-bar.tsx
+++ b/p2p-safe-swap/frontend/components/ui/tab-bar.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+export interface TabBarProps
+  extends Omit<React.ComponentProps<"div">, "onChange"> {
+  tabs: string[];
+  activeIndex: number;
+  onChange: (index: number) => void;
+}
+
+export function TabBar({
+  tabs,
+  activeIndex,
+  onChange,
+  className,
+  ...props
+}: TabBarProps) {
+  const tabRefs = React.useRef<(HTMLButtonElement | null)[]>([]);
+
+  const handleKeyDown = (e: React.KeyboardEvent, index: number) => {
+    let next = index;
+    if (e.key === "ArrowRight") next = (index + 1) % tabs.length;
+    else if (e.key === "ArrowLeft") next = (index - 1 + tabs.length) % tabs.length;
+    else if (e.key === "Home") next = 0;
+    else if (e.key === "End") next = tabs.length - 1;
+    else return;
+    e.preventDefault();
+    onChange(next);
+    tabRefs.current[next]?.focus();
+  };
+
+  return (
+    <div
+      data-slot="tab-bar"
+      role="tablist"
+      aria-orientation="horizontal"
+      className={cn(
+        "inline-flex items-center gap-1 rounded-full bg-primary/5 p-1",
+        className
+      )}
+      {...props}
+    >
+      {tabs.map((label, index) => {
+        const isActive = index === activeIndex;
+        return (
+          <button
+            key={index}
+            ref={(el) => {
+              tabRefs.current[index] = el;
+            }}
+            data-slot="tab-bar-tab"
+            data-state={isActive ? "active" : "inactive"}
+            role="tab"
+            type="button"
+            aria-selected={isActive}
+            tabIndex={isActive ? 0 : -1}
+            onClick={() => onChange(index)}
+            onKeyDown={(e) => handleKeyDown(e, index)}
+            className={cn(
+              "whitespace-nowrap rounded-full px-5 py-2 text-sm transition-colors",
+              "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1",
+              isActive
+                ? "bg-primary/15 font-medium text-primary"
+                : "font-normal text-muted-foreground hover:text-foreground"
+            )}
+          >
+            {label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}


### PR DESCRIPTION
## 🛠️ Issue
- Closes #284

## 📖 Description
- Adds a reusable `TabBar`: a horizontal tab selector that renders an array of string labels and emits the selected index via `onChange`. The active tab gets a filled green pill; inactive tabs are plain text — matching the issue reference.

## ✅ Changes made
- New client component `p2p-safe-swap/frontend/components/ui/tab-bar.tsx`.
- Props: `tabs: string[]`, `activeIndex: number`, `onChange: (index) => void` (+ optional `className` and standard `div` props via passthrough).
- Styling uses the project's semantic theme tokens (no hardcoded hex): green active pill via `--primary` (`bg-primary/15` + `text-primary`), `bg-primary/5` container, `text-muted-foreground` inactive, `ring-ring` focus.
- Accessibility: `role="tablist"/"tab"`, `aria-selected`, roving `tabindex`, keyboard navigation (Arrow Left/Right, Home, End), visible focus ring.
- shadcn idiom: `data-slot`, `data-state`, `ref`/`...props` passthrough.
- `npm run lint` and `tsc --noEmit` pass.

## 🖼️ Media (screenshots/videos)
- _Screenshot to be attached._
<img width="1023" height="663" alt="image" src="https://github.com/user-attachments/assets/e02c2a8b-7921-4cf8-a557-f66be23826dd" />


## 📜 Additional Notes
- No new dependencies, no env changes.
- Component is generic/reusable (the issue's "Quiero Comprar / Quiero Vender" is one use case).
