### PR TITLE
feat: add reusable Button component with variant support

### DIFF
--- a/p2p-safe-swap/frontend/components/ui/button.tsx
+++ b/p2p-safe-swap/frontend/components/ui/button.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import * as React from "react";
+import { cva, type VariantProps } from "class-variance-authority";
+import { cn } from "@/lib/utils";
+
+const buttonVariants = cva(
+  "inline-flex items-center justify-center rounded-full text-sm font-semibold tracking-wide transition-all duration-200 focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 active:scale-97 cursor-pointer select-none",
+  {
+    variants: {
+      variant: {
+        primary:
+          "bg-primary text-white shadow-xs hover:bg-primary/90 active:bg-primary/95 dark:text-zinc-50",
+        ghost:
+          "border border-solid border-zinc-200 bg-transparent text-zinc-700 hover:bg-zinc-50 hover:text-zinc-900 active:bg-zinc-100 dark:border-zinc-800 dark:text-zinc-300 dark:hover:bg-zinc-900 dark:hover:text-zinc-50 dark:active:bg-zinc-800/80",
+        danger:
+          "bg-red-50 text-red-600 border border-solid border-red-100 hover:bg-red-100/80 hover:text-red-700 active:bg-red-200/60 dark:bg-red-950/20 dark:text-red-400 dark:border-red-950/50 dark:hover:bg-red-950/40 dark:hover:text-red-300 dark:active:bg-red-950/60",
+      },
+    },
+    defaultVariants: {
+      variant: "primary",
+    },
+  }
+);
+
+export interface ButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement>,
+    VariantProps<typeof buttonVariants> {
+  label: string;
+  variant: "primary" | "ghost" | "danger";
+  disabled?: boolean;
+  onClick: () => void;
+}
+
+const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className, variant, label, disabled, onClick, ...props }, ref) => {
+    return (
+      <button
+        type="button"
+        className={cn(buttonVariants({ variant }), className)}
+        onClick={onClick}
+        disabled={disabled}
+        ref={ref}
+        {...props}
+      >
+        {label}
+      </button>
+    );
+  }
+);
+
+Button.displayName = "Button";
+
+export { Button, buttonVariants };


### PR DESCRIPTION
# 📝 feat: Create reusable Button component with variant support

## 🛠️ Issue
- Closes #285 

## 📖 Description
- Implemented a highly reusable, type-safe, and interactive `Button` component at `frontend/components/ui/button.tsx`.
- Defined style properties to support the three required variations: primary (emerald/mint green fill), ghost (border outline with transparent background), and danger (soft red tinted background).
- Configured dynamic responsiveness, dark mode variables compatibility, and smooth micro-interactions.

## ✅ Changes made
- **Created component at `frontend/components/ui/button.tsx`** conforming exactly to the requested props:
  - `label: string` (rendered text)
  - `variant: 'primary' | 'ghost' | 'danger'`
  - `disabled?: boolean` (handles opacity and interactive safety)
  - `onClick: () => void`
- **Aesthetic and UX enhancements**:
  - Leveraged `class-variance-authority` (cva) and `clsx` / `tailwind-merge` for robust custom class combination.
  - Capsule-shaped layout (`rounded-full`) matching the design specifications.
  - Micro-interactions added: tactile shrink transition on click (`active:scale-97`), smooth opacity transitions for hover actions, and focus ring outlines for improved accessibility.

## 🖼️ Media (screenshots/videos)

<img width="1020" height="854" alt="Screenshot From 2026-06-16 11-18-41" src="https://github.com/user-attachments/assets/704319fc-ac90-4501-b91b-de1be0da9ad1" />


## 📜 Additional Notes
- Verified that the production build completes successfully via `pnpm build`.
- Ran the linter (`pnpm lint`) to guarantee the file contains zero warnings or format errors.