### PR TITLE
feat: add DateGroupHeader UI component

### DIFF
--- a/p2p-safe-swap/app/page.tsx
+++ b/p2p-safe-swap/app/page.tsx
@@ -1,9 +1,20 @@
 import Image from "next/image";
+import { DateGroupHeader } from "@/frontend/components/ui/date-group-header";
 
 export default function Home() {
   return (
     <div className="flex flex-col flex-1 items-center justify-center bg-zinc-50 font-sans dark:bg-black">
       <main className="flex flex-1 w-full max-w-3xl flex-col items-center justify-between py-32 px-16 bg-white dark:bg-black sm:items-start">
+        {/* DateGroupHeader verification */}
+        <div className="w-full mb-8 border rounded-lg overflow-hidden">
+          <DateGroupHeader label="TODAY" />
+          <div className="px-4 py-3 text-sm text-zinc-600">Transaction A · $50.00</div>
+          <div className="px-4 py-3 text-sm text-zinc-600">Transaction B · $20.00</div>
+          <DateGroupHeader label="YESTERDAY" />
+          <div className="px-4 py-3 text-sm text-zinc-600">Transaction C · $75.00</div>
+          <DateGroupHeader label="JUNE" />
+          <div className="px-4 py-3 text-sm text-zinc-600">Transaction D · $10.00</div>
+        </div>
         <Image
           className="dark:invert"
           src="/next.svg"

--- a/p2p-safe-swap/frontend/components/ui/date-group-header.tsx
+++ b/p2p-safe-swap/frontend/components/ui/date-group-header.tsx
@@ -1,0 +1,14 @@
+interface DateGroupHeaderProps {
+  label: string;
+}
+
+export function DateGroupHeader({ label }: DateGroupHeaderProps) {
+  return (
+    <div className="flex items-center gap-3 px-4 py-2">
+      <span className="text-xs font-semibold uppercase tracking-widest text-muted-foreground">
+        {label}
+      </span>
+      <div className="h-px flex-1 bg-border" />
+    </div>
+  );
+}


### PR DESCRIPTION
Closes #283

## Summary

Adds a new `DateGroupHeader` component to the shared UI library for visually grouping lists of items under labelled date sections.

- **New file:** `frontend/components/ui/date-group-header.tsx` — a composable, themeable header row
- **Demo:** `app/page.tsx` updated to render three date groups with mock transactions, used during visual verification

---
<img width="946" height="608" alt="Screenshot 2026-06-17 200418" src="https://github.com/user-attachments/assets/29d9d1a7-3bbc-4757-928a-260d5af6355f" />


## Component

```tsx
import { DateGroupHeader } from "@/frontend/components/ui/date-group-header";

<DateGroupHeader label="TODAY" />
<DateGroupHeader label="YESTERDAY" />
<DateGroupHeader label="JUNE 2026" />
```

### Props

| Prop | Type | Description |
|------|------|-------------|
| `label` | `string` | Text displayed as the date group label |

### Design

- Label text: `text-xs font-semibold uppercase tracking-widest text-muted-foreground` — subtle, all-caps, spaced lettering
- Divider: a `flex-1 h-px bg-border` rule that fills the remaining row width
- Padding: `px-4 py-2` — consistent with list item spacing
- Fully responsive to light and dark themes via Tailwind CSS variables (`text-muted-foreground`, `bg-border`)

---

## Visual

**Light mode**

```
┌──────────────────────────────────────────────────────────┐
│  TODAY ─────────────────────────────────────────────────  │
│  Transaction A · $50.00                                   │
│  Transaction B · $20.00                                   │
│  YESTERDAY ──────────────────────────────────────────────  │
│  Transaction C · $75.00                                   │
│  JUNE ───────────────────────────────────────────────────  │
│  Transaction D · $10.00                                   │
└──────────────────────────────────────────────────────────┘
```

Verified rendering in both light and dark mode — dividers and label colours resolve correctly via CSS custom properties.

---

## Usage context

This component is intended for use in the transaction history view and any other list that benefits from chronological grouping. It is intentionally minimal — it carries no date-parsing logic and accepts a pre-formatted `label` string, keeping formatting decisions in the parent.

---

## Test plan

- [x] Visual verification: ran `npm run dev`, confirmed light and dark mode screenshots match expected design
- [ ] Integrate into the actual transaction list view (follow-up)
- [ ] Add to Storybook / component catalogue (follow-up)

> **Note:** The `app/page.tsx` changes are demo scaffolding added for verification. They can be removed in this PR or as a quick follow-up once the component is wired into its real location.

🤖 Generated with [Claude Code](https://claude.com/claude-code)