### PR TITLE
feat: add Transaction Row and Wallet Badge components

### DIFF
--- a/p2p-safe-swap/frontend/components/ui/transaction-row.tsx
+++ b/p2p-safe-swap/frontend/components/ui/transaction-row.tsx
@@ -1,0 +1,78 @@
+import * as React from "react";
+import { Clock } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { WalletBadge } from "@/frontend/components/ui/wallet-badge";
+
+export interface TransactionRowProps extends React.ComponentProps<"div"> {
+  address: string;
+  memo?: string;
+  timestamp: string;
+  amount: number;
+  direction: "in" | "out";
+}
+
+function truncateAddress(address: string, head = 4, tail = 4): string {
+  if (address.length <= head + tail + 1) {
+    return address;
+  }
+
+  return `${address.slice(0, head)}…${address.slice(-tail)}`;
+}
+
+function formatAmount(amount: number, direction: "in" | "out"): string {
+  const formatted = new Intl.NumberFormat("en-US", {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  }).format(Math.abs(amount));
+
+  return direction === "in" ? `+${formatted}` : `−${formatted}`;
+}
+
+export function TransactionRow({
+  address,
+  memo,
+  timestamp,
+  amount,
+  direction,
+  className,
+  ...props
+}: TransactionRowProps) {
+  const formattedAmount = formatAmount(amount, direction);
+
+  return (
+    <div
+      data-slot="transaction-row"
+      className={cn(
+        "flex items-center gap-3 rounded-xl border bg-card p-3",
+        className
+      )}
+      {...props}
+    >
+      <WalletBadge address={address} />
+
+      <div className="min-w-0 flex-1">
+        <p className="truncate text-sm font-semibold text-foreground">
+          {truncateAddress(address)}
+        </p>
+        {memo ? (
+          <p className="truncate text-sm text-muted-foreground">{memo}</p>
+        ) : null}
+      </div>
+
+      <div className="shrink-0 text-right">
+        <p
+          className={cn(
+            "text-sm font-semibold tabular-nums",
+            direction === "in" ? "text-primary" : "text-foreground"
+          )}
+        >
+          {formattedAmount}
+        </p>
+        <div className="mt-0.5 flex items-center justify-end gap-1 text-xs text-muted-foreground">
+          <Clock className="size-3.5 shrink-0" aria-hidden="true" />
+          <span>{timestamp}</span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/p2p-safe-swap/frontend/components/ui/wallet-badge.tsx
+++ b/p2p-safe-swap/frontend/components/ui/wallet-badge.tsx
@@ -1,0 +1,62 @@
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+export interface WalletBadgeProps extends React.ComponentProps<"div"> {
+  address: string;
+  size?: "sm" | "md";
+}
+
+const sizeClasses = {
+  sm: "size-9 text-xs",
+  md: "size-11 text-sm",
+} as const;
+
+const badgeColors = [
+  "bg-[#EBF4F0] text-[#54615B]",
+  "bg-[#E1EBE6] text-[#24312B]",
+  "bg-[#D2DED8] text-[#1A2721]",
+  "bg-primary/15 text-primary",
+] as const;
+
+function hashAddress(address: string): number {
+  let hash = 0;
+  for (let i = 0; i < address.length; i += 1) {
+    hash = (hash + address.charCodeAt(i) * (i + 1)) % 2147483647;
+  }
+  return hash;
+}
+
+function getInitials(address: string): string {
+  const normalized = address.replace(/^0x/i, "").replace(/[^a-zA-Z0-9]/g, "");
+  if (normalized.length >= 2) {
+    return normalized.slice(0, 2).toUpperCase();
+  }
+  return address.slice(0, 2).toUpperCase();
+}
+
+export function WalletBadge({
+  address,
+  size = "md",
+  className,
+  ...props
+}: WalletBadgeProps) {
+  const initials = getInitials(address);
+  const colorClass = badgeColors[hashAddress(address) % badgeColors.length];
+
+  return (
+    <div
+      data-slot="wallet-badge"
+      title={address}
+      aria-hidden="true"
+      className={cn(
+        "flex shrink-0 items-center justify-center rounded-full font-medium",
+        sizeClasses[size],
+        colorClass,
+        className
+      )}
+      {...props}
+    >
+      {initials}
+    </div>
+  );
+}


### PR DESCRIPTION
# 📝 Pull Request Title

## 🛠️ Issue
- [x] Closes #281

## 📖 Description
- Adds the reusable `TransactionRow` component for transaction lists and the home activity feed.
- Adds a supporting `WalletBadge` component that renders deterministic initials and color styling from a wallet address.

## ✅ Changes made
- Created `WalletBadge` in `p2p-safe-swap/frontend/components/ui/wallet-badge.tsx`
- Created `TransactionRow` in `p2p-safe-swap/frontend/components/ui/transaction-row.tsx`
- Implemented truncated wallet address display instead of names
- Added optional memo, timestamp with clock icon, and direction-based amount styling (`in` = green, `out` = neutral)

## 🖼️ Media (screenshots/videos)
<img width="1510" height="771" alt="Screenshot 2026-06-17 at 2 24 06 PM" src="https://github.com/user-attachments/assets/4a77f425-93ae-4d91-879d-af4255c4e07c" />

## 📜 Additional Notes
- `TransactionRow` props: `address`, `memo?`, `timestamp`, `amount`, `direction`
- Outgoing amounts use neutral foreground color per issue spec