### PR TITLE
feat: add search bar component

### DIFF
--- a/p2p-safe-swap/frontend/components/ui/search-bar.tsx
+++ b/p2p-safe-swap/frontend/components/ui/search-bar.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import * as React from "react";
+import { Search } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+export interface SearchBarProps
+  extends Omit<React.ComponentProps<"input">, "onChange" | "value"> {
+  value: string;
+  onChange: (value: string) => void;
+  placeholder?: string;
+}
+
+export function SearchBar({
+  value,
+  onChange,
+  placeholder = "Buscar transacciones...",
+  className,
+  ...props
+}: SearchBarProps) {
+  return (
+    <div
+      data-slot="search-bar"
+      className={cn(
+        "flex items-center gap-2 rounded-full bg-primary/5 px-4 py-2",
+        "focus-within:ring-2 focus-within:ring-ring focus-within:ring-offset-1",
+        className
+      )}
+    >
+      <Search aria-hidden className="size-4 shrink-0 text-muted-foreground" />
+      <input
+        type="text"
+        role="searchbox"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        placeholder={placeholder}
+        className={cn(
+          "w-full bg-transparent text-sm text-foreground outline-none",
+          "placeholder:text-muted-foreground"
+        )}
+        {...props}
+      />
+    </div>
+  );
+}


### PR DESCRIPTION
# 📝 Pull Request Title

feat: add search bar component

## 🛠️ Issue
- Closes #282

## 📖 Description
- Adds a reusable SearchBar UI component with a leading magnifier icon.
- Emits the current input value on every keystroke for filtering transaction lists by wallet address or amount in the MVP.

## ✅ Changes made
- Created `p2p-safe-swap/frontend/components/ui/search-bar.tsx`
- Implemented controlled `value` and `onChange` props
- Added optional `placeholder` prop (defaults to "Buscar transacciones...")
- Styled as a pill-shaped search input consistent with existing UI components

## 🖼️ Media (screenshots/videos)
<img width="1485" height="761" alt="Screenshot 2026-06-17 at 3 01 44 PM" src="https://github.com/user-attachments/assets/735d2c3a-882f-4d90-9dd4-fcdda5a7dc45" />

## 📜 Additional Notes
- Follows the same patterns as `tab-bar.tsx` (`"use client"`, `cn`, `data-slot`, lucide-react icons)