### PR TITLE
Feature/create payment bubble component

### DIFF
--- a/p2p-safe-swap/frontend/components/PaymentBubble/PaymentBubble.tsx
+++ b/p2p-safe-swap/frontend/components/PaymentBubble/PaymentBubble.tsx
@@ -2,12 +2,8 @@
 
 import { ArrowUpRight, ArrowDownLeft, ArrowRight, Check, X } from "lucide-react";
 import { PaymentBubbleProperties } from "./types";
-import { formatCurrency } from "./utils";
-
-const variantLabel = {
-  sent:    "PAGO ENVIADO",
-  request: "SOLICITUD DE PAGO",
-} as const;
+import { formatCurrency, translations } from "./utils";
+import { Button } from "../ui/Button/Button";
 
 export function PaymentBubble({
   amount,
@@ -16,12 +12,14 @@ export function PaymentBubble({
   variant,
   status,
   side,
+  lang = "en",
   onPay,
   onReject,
   onViewReceipt,
 }: PaymentBubbleProperties) {
-  const isSent   = variant === "sent";
-  const isDark   = isSent;
+  const isSent = variant === "sent";
+  const isDark = isSent;
+  const t      = translations[lang];
 
   const cornerClass = side === "sender"
     ? "rounded-tl-3xl rounded-tr-3xl rounded-bl-3xl rounded-br-md"
@@ -30,7 +28,6 @@ export function PaymentBubble({
   return (
     <div className={`w-72 overflow-hidden ${cornerClass} ${isDark ? "bg-[#0E1C16] text-white" : "bg-white text-[#1A2721] border border-[#D2DED8]"}`}>
 
-    
       <div className="p-4 flex flex-col gap-3">
         <div className="flex items-center gap-3">
           <div className={`w-10 h-10 rounded-full flex items-center justify-center shrink-0 ${isDark ? "bg-[#24312B]" : "bg-[#EBF4F0]"}`}>
@@ -41,7 +38,7 @@ export function PaymentBubble({
           </div>
           <div>
             <p className="text-xs font-semibold tracking-widest text-[#95A29C]">
-              {variantLabel[variant]}
+              {isSent ? t.sent : t.request}
             </p>
             <p className={`text-2xl font-bold leading-tight ${isDark ? "text-white" : "text-[#1A2721]"}`}>
               {formatCurrency(amount)} {currency}
@@ -56,48 +53,42 @@ export function PaymentBubble({
         )}
       </div>
 
- 
       <div className={`h-px ${isDark ? "bg-[#24312B]" : "bg-[#D2DED8]"}`} />
 
-  
       <div className={`px-4 py-3 flex items-center justify-between ${isDark ? "bg-[#162c23]" : "bg-[#e8f5ef]"}`}>
 
         {status === "completed" && <>
           <span className="flex items-center gap-1 text-xs text-[#95A29C]">
             <Check size={14} />
-            Completado
+            {t.completed}
           </span>
           <button onClick={onViewReceipt} className={`flex items-center gap-1 text-xs ${isDark ? "text-[#95A29C] hover:text-white" : "text-[#54615B] hover:text-[#1A2721]"} transition-colors cursor-pointer`}>
-            Ver recibo <ArrowRight size={12} />
+            {t.viewReceipt} <ArrowRight size={12} />
           </button>
         </>}
 
         {status === "pending" && variant === "request" && <>
           <span className="flex items-center gap-1.5 text-xs text-[#54615B]">
             <span className="w-1.5 h-1.5 rounded-full bg-[#D2DED8]" />
-            Pendiente
+            {t.pending}
           </span>
           <div className="flex items-center gap-4">
-            <button onClick={onReject} className="text-xs text-[#54615B] hover:text-[#1A2721] transition-colors cursor-pointer">
-              Rechazar
-            </button>
-            <button onClick={onPay} className="bg-[#23C987] hover:bg-[#1db87a] text-white rounded-full px-4 py-1.5 text-xs font-semibold transition-colors cursor-pointer">
-              Pagar
-            </button>
+            <Button variant="ghost" size="sm" label={t.reject} onClick={onReject} />
+            <Button variant="primary" size="sm" label={t.pay} onClick={onPay} />
           </div>
         </>}
 
         {status === "pending" && variant === "sent" && (
           <span className="flex items-center gap-1.5 text-sm text-[#95A29C]">
             <span className="w-1.5 h-1.5 rounded-full bg-[#95A29C]" />
-            Pendiente
+            {t.pending}
           </span>
         )}
 
         {status === "rejected" && (
           <span className="flex items-center gap-1.5 text-sm text-[#FF5957]">
             <X size={14} />
-            Rechazado
+            {t.rejected}
           </span>
         )}
 

--- a/p2p-safe-swap/frontend/components/PaymentBubble/PaymentBubble.tsx
+++ b/p2p-safe-swap/frontend/components/PaymentBubble/PaymentBubble.tsx
@@ -1,0 +1,107 @@
+'use client'
+
+import { ArrowUpRight, ArrowDownLeft, ArrowRight, Check, X } from "lucide-react";
+import { PaymentBubbleProperties } from "./types";
+import { formatCurrency } from "./utils";
+
+const variantLabel = {
+  sent:    "PAGO ENVIADO",
+  request: "SOLICITUD DE PAGO",
+} as const;
+
+export function PaymentBubble({
+  amount,
+  currency,
+  memo,
+  variant,
+  status,
+  side,
+  onPay,
+  onReject,
+  onViewReceipt,
+}: PaymentBubbleProperties) {
+  const isSent   = variant === "sent";
+  const isDark   = isSent;
+
+  const cornerClass = side === "sender"
+    ? "rounded-tl-3xl rounded-tr-3xl rounded-bl-3xl rounded-br-md"
+    : "rounded-tl-3xl rounded-tr-3xl rounded-bl-md rounded-br-3xl";
+
+  return (
+    <div className={`w-72 overflow-hidden ${cornerClass} ${isDark ? "bg-[#0E1C16] text-white" : "bg-white text-[#1A2721] border border-[#D2DED8]"}`}>
+
+    
+      <div className="p-4 flex flex-col gap-3">
+        <div className="flex items-center gap-3">
+          <div className={`w-10 h-10 rounded-full flex items-center justify-center shrink-0 ${isDark ? "bg-[#24312B]" : "bg-[#EBF4F0]"}`}>
+            {isSent
+              ? <ArrowUpRight size={18} className="text-white" />
+              : <ArrowDownLeft size={18} className="text-[#23C987]" />
+            }
+          </div>
+          <div>
+            <p className="text-xs font-semibold tracking-widest text-[#95A29C]">
+              {variantLabel[variant]}
+            </p>
+            <p className={`text-2xl font-bold leading-tight ${isDark ? "text-white" : "text-[#1A2721]"}`}>
+              {formatCurrency(amount)} {currency}
+            </p>
+          </div>
+        </div>
+
+        {memo && (
+          <p className={`text-sm ${isDark ? "text-[#95A29C]" : "text-[#54615B]"}`}>
+            "{memo}"
+          </p>
+        )}
+      </div>
+
+ 
+      <div className={`h-px ${isDark ? "bg-[#24312B]" : "bg-[#D2DED8]"}`} />
+
+  
+      <div className={`px-4 py-3 flex items-center justify-between ${isDark ? "bg-[#162c23]" : "bg-[#e8f5ef]"}`}>
+
+        {status === "completed" && <>
+          <span className="flex items-center gap-1 text-xs text-[#95A29C]">
+            <Check size={14} />
+            Completado
+          </span>
+          <button onClick={onViewReceipt} className={`flex items-center gap-1 text-xs ${isDark ? "text-[#95A29C] hover:text-white" : "text-[#54615B] hover:text-[#1A2721]"} transition-colors cursor-pointer`}>
+            Ver recibo <ArrowRight size={12} />
+          </button>
+        </>}
+
+        {status === "pending" && variant === "request" && <>
+          <span className="flex items-center gap-1.5 text-xs text-[#54615B]">
+            <span className="w-1.5 h-1.5 rounded-full bg-[#D2DED8]" />
+            Pendiente
+          </span>
+          <div className="flex items-center gap-4">
+            <button onClick={onReject} className="text-xs text-[#54615B] hover:text-[#1A2721] transition-colors cursor-pointer">
+              Rechazar
+            </button>
+            <button onClick={onPay} className="bg-[#23C987] hover:bg-[#1db87a] text-white rounded-full px-4 py-1.5 text-xs font-semibold transition-colors cursor-pointer">
+              Pagar
+            </button>
+          </div>
+        </>}
+
+        {status === "pending" && variant === "sent" && (
+          <span className="flex items-center gap-1.5 text-sm text-[#95A29C]">
+            <span className="w-1.5 h-1.5 rounded-full bg-[#95A29C]" />
+            Pendiente
+          </span>
+        )}
+
+        {status === "rejected" && (
+          <span className="flex items-center gap-1.5 text-sm text-[#FF5957]">
+            <X size={14} />
+            Rechazado
+          </span>
+        )}
+
+      </div>
+    </div>
+  );
+}

--- a/p2p-safe-swap/frontend/components/PaymentBubble/types/index.ts
+++ b/p2p-safe-swap/frontend/components/PaymentBubble/types/index.ts
@@ -1,0 +1,15 @@
+export type PaymentBubbleSide    = "sender" | "receiver";
+export type PaymentBubbleVariant = "sent" | "request";
+export type PaymentBubbleStatus  = "completed" | "pending" | "rejected";
+
+export interface PaymentBubbleProperties {
+  amount:    number;
+  currency:  string;
+  memo?:     string;
+  variant:   PaymentBubbleVariant;
+  status:    PaymentBubbleStatus;
+  side:      PaymentBubbleSide;
+  onPay:          () => void;
+  onReject:       () => void;
+  onViewReceipt?: () => void;
+}

--- a/p2p-safe-swap/frontend/components/PaymentBubble/types/index.ts
+++ b/p2p-safe-swap/frontend/components/PaymentBubble/types/index.ts
@@ -1,3 +1,4 @@
+export type PaymentBubbleLang    = "es" | "en";
 export type PaymentBubbleSide    = "sender" | "receiver";
 export type PaymentBubbleVariant = "sent" | "request";
 export type PaymentBubbleStatus  = "completed" | "pending" | "rejected";
@@ -9,7 +10,8 @@ export interface PaymentBubbleProperties {
   variant:   PaymentBubbleVariant;
   status:    PaymentBubbleStatus;
   side:      PaymentBubbleSide;
-  onPay:          () => void;
-  onReject:       () => void;
-  onViewReceipt?: () => void;
+  lang?:     PaymentBubbleLang;
+  onPay?:          () => void;
+  onReject?:       () => void;
+  onViewReceipt?:  () => void;
 }

--- a/p2p-safe-swap/frontend/components/PaymentBubble/utils/index.ts
+++ b/p2p-safe-swap/frontend/components/PaymentBubble/utils/index.ts
@@ -1,0 +1,3 @@
+export function formatCurrency(amount: number): string {
+  return amount.toFixed(2);
+}

--- a/p2p-safe-swap/frontend/components/PaymentBubble/utils/index.ts
+++ b/p2p-safe-swap/frontend/components/PaymentBubble/utils/index.ts
@@ -1,3 +1,28 @@
+import { PaymentBubbleLang } from "../types";
+
+export const translations = {
+  es: {
+    sent:       "PAGO ENVIADO",
+    request:    "SOLICITUD DE PAGO",
+    completed:  "Completado",
+    pending:    "Pendiente",
+    rejected:   "Rechazado",
+    viewReceipt:"Ver recibo",
+    reject:     "Rechazar",
+    pay:        "Pagar",
+  },
+  en: {
+    sent:       "PAYMENT SENT",
+    request:    "PAYMENT REQUEST",
+    completed:  "Completed",
+    pending:    "Pending",
+    rejected:   "Rejected",
+    viewReceipt:"View receipt",
+    reject:     "Reject",
+    pay:        "Pay",
+  },
+} satisfies Record<PaymentBubbleLang, object>;
+
 export function formatCurrency(amount: number): string {
   return amount.toFixed(2);
 }


### PR DESCRIPTION
# 📝 feat: Create PaymentBubble component

## 🛠️ Issue
- Closes #279

## 📖 Description

Implemented and structured the `PaymentBubble` component for use inside a chat interface, representing both outgoing payments and incoming payment requests with mutable status states.

## ✅ Changes made
- [x] Built the `PaymentBubble` component using Tailwind CSS with two visual variants: `sent` (dark theme) and `request` (light theme).
- [x] Added a `status` prop (`"pending" | "completed" | "rejected"`) that controls the footer content: action buttons, receipt link, or rejection indicator.
- [x] Added a `side` prop (`"sender" | "receiver"`) that adjusts the bubble's corner radius to simulate a chat message tail — bottom-right for sender, bottom-left for receiver.
- [x] Made `onPay`, `onReject` and `onViewReceipt` optional — each is only relevant to a specific status, avoiding unnecessary required props.
- [x] Added as extra value: Added lang prop ("es" | "en") with translations in utils/index.ts, , defaulting to "en".
- [x] Integrated the `Button` component for the `Rechazar` (ghost) and `Pagar` (primary) actions in the pending state.
- [x] Structured with dedicated `types/` and `utils/` subfolders, consistent with the project's component organization.

## 🖼️ Media (screenshots/videos)
<img width="437" height="1044" alt="image" src="https://github.com/user-attachments/assets/0eae2523-470c-46df-9785-50a0c9dcc2c3" />


## 📜 Additional Notes

### Example Usage

```tsx
<PaymentBubble
  variant="request"
  status="pending"
  side="receiver"
  amount={6.00}
  currency="€"
  memo="Café de mañana ☕"
  lang="es"
  onPay={() => {}}
  onReject={() => {}}
/>
