### PR TITLE
Feat/chat bubble component

### DIFF
--- a/p2p-safe-swap/app/globals.css
+++ b/p2p-safe-swap/app/globals.css
@@ -19,6 +19,8 @@
   --color-border: var(--border);
   --color-input: var(--input);
   --color-ring: var(--ring);
+  --color-chat-bubble-outgoing: var(--chat-bubble-outgoing);
+  --color-chat-bubble-outgoing-foreground: var(--chat-bubble-outgoing-foreground);
   --radius-sm: calc(var(--radius) - 4px);
   --radius-md: calc(var(--radius) - 2px);
   --radius-lg: var(--radius);
@@ -44,6 +46,8 @@
   --border: hsl(240 5.9% 90%);
   --input: hsl(240 5.9% 90%);
   --ring: hsl(164 98% 33%);
+  --chat-bubble-outgoing: #052016;
+  --chat-bubble-outgoing-foreground: hsl(0 0% 98%);
   --radius: 0.75rem;
 }
 

--- a/p2p-safe-swap/frontend/components/chat/chat-message-bubble.tsx
+++ b/p2p-safe-swap/frontend/components/chat/chat-message-bubble.tsx
@@ -53,7 +53,7 @@ export function ChatMessageBubble({
         className={cn(
           "max-w-[78%] rounded-2xl px-4 py-2.5 text-sm leading-relaxed shadow-sm",
           isSelf
-            ? "rounded-br-md bg-foreground text-background"
+            ? "rounded-br-md bg-chat-bubble-outgoing text-chat-bubble-outgoing-foreground"
             : "rounded-bl-md bg-muted text-foreground"
         )}
       >

--- a/p2p-safe-swap/frontend/components/chat/chat-message-bubble.tsx
+++ b/p2p-safe-swap/frontend/components/chat/chat-message-bubble.tsx
@@ -1,0 +1,76 @@
+import { cn } from "@/lib/utils";
+import type { TextMessage } from "./types";
+import { formatTime } from "./utils";
+
+export interface ChatMessageBubbleProps {
+  message: TextMessage;
+  className?: string;
+}
+
+function DeliveryTick({ status }: { status: TextMessage["deliveryStatus"] }) {
+  if (!status) return null;
+  const isRead = status === "read";
+
+  return (
+    <svg
+      width="14"
+      height="14"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2.2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-label={`Estado: ${status}`}
+      className={cn(
+        "shrink-0",
+        isRead ? "text-primary" : "text-muted-foreground"
+      )}
+    >
+      <polyline points="3 13 8 18 17 7" />
+      {status !== "sent" && <polyline points="9 13 14 18 22 7" />}
+    </svg>
+  );
+}
+
+export function ChatMessageBubble({
+  message,
+  className,
+}: ChatMessageBubbleProps) {
+  const isSelf = message.author === "self";
+
+  return (
+    <div
+      data-slot="chat-message-bubble"
+      data-author={message.author}
+      className={cn(
+        "flex w-full flex-col",
+        isSelf ? "items-end" : "items-start",
+        className
+      )}
+    >
+      <div
+        className={cn(
+          "max-w-[78%] rounded-2xl px-4 py-2.5 text-sm leading-relaxed shadow-sm",
+          isSelf
+            ? "rounded-br-md bg-foreground text-background"
+            : "rounded-bl-md bg-muted text-foreground"
+        )}
+      >
+        <p className="whitespace-pre-wrap break-words">{message.text}</p>
+      </div>
+
+      <div
+        className={cn(
+          "mt-1 flex items-center gap-1 px-1 text-[11px] text-muted-foreground tabular-nums",
+          isSelf ? "justify-end" : "justify-start"
+        )}
+      >
+        <time dateTime={new Date(message.timestamp).toISOString()}>
+          {formatTime(message.timestamp)}
+        </time>
+        {isSelf && <DeliveryTick status={message.deliveryStatus} />}
+      </div>
+    </div>
+  );
+}

--- a/p2p-safe-swap/frontend/components/chat/index.ts
+++ b/p2p-safe-swap/frontend/components/chat/index.ts
@@ -1,0 +1,7 @@
+export { ChatMessageBubble } from "./chat-message-bubble";
+export type { ChatMessageBubbleProps } from "./chat-message-bubble";
+export type {
+  ChatMessageBase,
+  MessageAuthor,
+  TextMessage,
+} from "./types";

--- a/p2p-safe-swap/frontend/components/chat/types.ts
+++ b/p2p-safe-swap/frontend/components/chat/types.ts
@@ -1,0 +1,13 @@
+export type MessageAuthor = "self" | "counterpart";
+
+export interface ChatMessageBase {
+  id: string;
+  timestamp: string | Date;
+  author: MessageAuthor;
+}
+
+export interface TextMessage extends ChatMessageBase {
+  type: "text";
+  text: string;
+  deliveryStatus?: "sent" | "delivered" | "read";
+}

--- a/p2p-safe-swap/frontend/components/chat/utils.ts
+++ b/p2p-safe-swap/frontend/components/chat/utils.ts
@@ -1,0 +1,8 @@
+export function formatTime(timestamp: string | Date): string {
+  const date = typeof timestamp === "string" ? new Date(timestamp) : timestamp;
+  return new Intl.DateTimeFormat("es-ES", {
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false,
+  }).format(date);
+}


### PR DESCRIPTION
# 📝 Chat Bubble Component

## 🛠️ Issue
- Closes #280

## 📖 Description
Adds the `ChatMessageBubble` component for rendering text messages inside a chat thread. It supports two variants — `incoming` (left-aligned, light background) and `outgoing` (right-aligned, dark background) — and renders the message text, a timestamp, and (for outgoing messages) an optional delivery status indicator.

The bubble accepts a structured `TextMessage` prop carrying the message id, text, timestamp, author, and an optional delivery status. This keeps the component self-contained and lets consumers drive both the alignment/variant and the WhatsApp-style ticks without prop drilling.

## ✅ Changes made
- `frontend/components/chat/chat-message-bubble.tsx`: `ChatMessageBubble` component.
  - `incoming` / `outgoing` variants resolved from `message.author` (`"counterpart"` / `"self"`).
  - `max-w-[78%]` and asymmetric rounded corners (`rounded-br-md` / `rounded-bl-md`) per the reference images.
  - `whitespace-pre-wrap` + `break-words` so multiline messages and unbreakable strings (e.g. wallet addresses) render correctly.
  - Inline `DeliveryTick`: `sent` → single tick, `delivered` → double tick (muted), `read` → double tick (`text-primary`). Only rendered for outgoing messages.
- `frontend/components/chat/types.ts`: `MessageAuthor`, `ChatMessageBase`, `TextMessage`.
- `frontend/components/chat/utils.ts`: `formatTime` helper (24h, `es-ES` locale).
- `frontend/components/chat/index.ts`: barrel export for the component and its types.

All styling uses the design tokens from `app/globals.css` (no hardcoded hex / rgb / hsl), so dark mode works automatically.

## 🖼️ Media (screenshots/videos)
- _(adjuntar screenshots: incoming / outgoing / sent / delivered / read / long text / multiline)_
<img width="478" height="684" alt="Screenshot 2026-06-19 at 2 59 37 PM" src="https://github.com/user-attachments/assets/cd824c84-ccd1-4498-b820-f40e6e2d4750" />
<img width="476" height="785" alt="Screenshot 2026-06-19 at 2 59 57 PM" src="https://github.com/user-attachments/assets/bae879be-9d35-4a85-a17c-ae2b4fddf4dc" />

## 📜 Additional Notes
- **Commit history** is split bottom-up so every commit leaves the repo in a buildable state:
  1. `feat(chat): add message types for chat module`
  2. `feat(chat): add formatTime helper`
  3. `feat(chat): add ChatMessageBubble component`
  4. `chore(chat): expose ChatMessageBubble via barrel export`

