### PR TITLE
feat(ui): add DateGroup component for transaction list dividers

### DIFF
--- a/p2p-safe-swap/frontend/components/ui/date-group.tsx
+++ b/p2p-safe-swap/frontend/components/ui/date-group.tsx
@@ -1,0 +1,21 @@
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+export interface DateGroupProps extends React.ComponentProps<"h3"> {
+  label: string;
+}
+
+export function DateGroup({ label, className, ...props }: DateGroupProps) {
+  return (
+    <h3
+      data-slot="date-group"
+      className={cn(
+        "px-1 text-xs font-medium uppercase tracking-wider text-muted-foreground",
+        className
+      )}
+      {...props}
+    >
+      {label}
+    </h3>
+  );
+}

--- a/p2p-safe-swap/frontend/components/ui/date-group.tsx
+++ b/p2p-safe-swap/frontend/components/ui/date-group.tsx
@@ -10,7 +10,7 @@ export function DateGroup({ label, className, ...props }: DateGroupProps) {
     <h3
       data-slot="date-group"
       className={cn(
-        "px-1 text-xs font-medium uppercase tracking-wider text-muted-foreground",
+        "px-1 text-[11px] font-normal uppercase tracking-[0.18em] text-muted-foreground",
         className
       )}
       {...props}


### PR DESCRIPTION
## 🛠️ Issue
Closes #283

## 📖 Description
Adds the `DateGroup` component — a muted uppercase label that acts as a visual divider between transaction groups in a list (e.g. `HOY`, `AYER`, `JUNIO`). Pure stateless UI atom, no new design tokens, no new dependencies.

The component renders a semantic `<h3>` instead of a styled `<div>` so screen readers can navigate between date groups. Uppercase is delegated to CSS (`uppercase` utility), keeping the DOM text in its original casing — better for accessibility, copy/paste, and SEO.

Public API is intentionally minimal: a required `label: string` plus passthrough of standard `<h3>` attributes via `React.ComponentProps<"h3">`, mirroring the convention used by `TransactionRow` and `WalletBadge`.

## ✅ Changes made
- Added `frontend/components/ui/date-group.tsx` exporting `DateGroup` and `DateGroupProps`
- Uses `data-slot="date-group"` for testing/styling hooks, consistent with the rest of `frontend/components/ui/`
- Typography matches the reference design: `text-[11px] font-normal uppercase tracking-[0.18em] text-muted-foreground`

## 📦 How to use it

**Import**

```tsx
import { DateGroup } from "@/frontend/components/ui/date-group";
```

**Props**

| Prop | Type | Required | Description |
|------|------|----------|-------------|
| `label` | `string` | Yes | Text shown as the divider. Pass `"junio"` or `"JUNIO"` — CSS handles the uppercase. |
| `...props` | `React.ComponentProps<"h3">` | No | Any `<h3>` attribute (`className`, `id`, `aria-*`, etc.). |

**Minimal usage**

```tsx
<DateGroup label="HOY" />
```

**Recommended integration with `TransactionRow`**

This is the structure that reproduces the look from #283:

```tsx
<section className="flex flex-col gap-4">
  {groups.map((group) => (
    <div key={group.label} className="flex flex-col gap-2">
      <DateGroup label={group.label} />
      <div className="flex flex-col gap-2">
        {group.items.map((tx) => (
          <TransactionRow key={tx.id} {...tx} />
        ))}
      </div>
    </div>
  ))}
</section>
```

- `gap-4` on the outer wrapper separates date groups (HOY → AYER → JUNIO).
- `gap-2` on the inner wrappers handles label↔items and item↔item spacing.
- Keep spacing in the parent — never on the `DateGroup` itself.

## 🖼️ Media

<img width="595" alt="DateGroup integrated in transaction list" src="https://github.com/user-attachments/assets/e5051e47-05bb-4c35-8c72-39ecc6622679" />

<img width="565" alt="DateGroup isolated cases" src="https://github.com/user-attachments/assets/32e305c5-d2b9-433c-a4ac-2d9b90634353" />

<img width="739" alt="Full transactions dev page with search and tabs" src="https://github.com/user-attachments/assets/d5392589-eb90-4ebb-b59c-5e4ee65a29ee" />

## 📜 Additional Notes
- **Semantic `<h3>`**: respects the natural page hierarchy (`h1` page → `h2` section → `h3` date group).
- **Uppercase in CSS, not JS**: keeps the source casing in the DOM for screen readers.
- **Flat file, no folder**: matches `transaction-row.tsx` and `wallet-badge.tsx`. The component has no types/utils that justify a barrel.
- **Out of scope**: integration into the real `TransactionList` page — that lands with #275.
